### PR TITLE
Add KoHttp as http client (#14)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.bundling.Jar
-
 plugins {
     kotlin("jvm") version "1.3.50"
     `maven-publish`
@@ -23,6 +21,7 @@ dependencies {
     val htmlUnitVersion = "2.36.0"
     val assertkVersion = "0.13"
     val striktVersion = "0.22.2"
+    val kohttpVersion = "0.11.0"
 
     val junitVersion = "5.5.2"
     val testContainersVersion = "1.12.2"
@@ -34,6 +33,7 @@ dependencies {
     implementation("org.jsoup:jsoup:$jsoupVersion")
     implementation("io.strikt:strikt-core:$striktVersion")
     implementation("net.sourceforge.htmlunit:htmlunit:$htmlUnitVersion")
+    implementation("io.github.rybalkinsd:kohttp:$kohttpVersion")
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     compileOnly("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 

--- a/src/main/kotlin/it/skrape/core/Request.kt
+++ b/src/main/kotlin/it/skrape/core/Request.kt
@@ -4,7 +4,8 @@ import org.jsoup.Connection
 
 data class Request(
         var mode: Mode = Mode.SOURCE,
-        var url: String = "http://localhost:8080",
+        // trailing slash is required
+        var url: String = "http://localhost:8080/",
         var method: Method = Method.GET,
         var userAgent: String = "Mozilla/5.0 skrape.it",
         var headers: Map<String, String> = emptyMap(),

--- a/src/main/kotlin/it/skrape/core/Scraper.kt
+++ b/src/main/kotlin/it/skrape/core/Scraper.kt
@@ -1,8 +1,7 @@
 package it.skrape.core
 
 import it.skrape.core.fetcher.BrowserFetcher
-import it.skrape.core.fetcher.HttpFetcher
-import org.jsoup.nodes.Document
+import it.skrape.core.fetcher.KoFetcher
 
 
 class Scraper(val request: Request = Request()) {
@@ -13,7 +12,7 @@ class Scraper(val request: Request = Request()) {
 
         return when (request.mode) {
             Mode.DOM -> BrowserFetcher(request).fetch()
-            Mode.SOURCE -> HttpFetcher(request).fetch()
+            Mode.SOURCE -> KoFetcher(request).fetch()
         }
     }
 }

--- a/src/main/kotlin/it/skrape/core/fetcher/BrowserFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/BrowserFetcher.kt
@@ -1,10 +1,6 @@
 package it.skrape.core.fetcher
 
-import com.gargoylesoftware.htmlunit.BrowserVersion
-import com.gargoylesoftware.htmlunit.NicelyResynchronizingAjaxController
-import com.gargoylesoftware.htmlunit.Page
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler
-import com.gargoylesoftware.htmlunit.WebClient
+import com.gargoylesoftware.htmlunit.*
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import com.gargoylesoftware.htmlunit.util.Cookie
 import com.gargoylesoftware.htmlunit.util.NameValuePair
@@ -14,9 +10,9 @@ import it.skrape.exceptions.UnsupportedRequestOptionException
 import org.jsoup.Connection
 import java.net.URL
 
-class BrowserFetcher(private val request: Request) {
+class BrowserFetcher(private val request: Request): Fetcher {
 
-    fun fetch(): Result {
+    override fun fetch(): Result {
 
         if (request.method != Connection.Method.GET)
             throw UnsupportedRequestOptionException("Browser mode only supports the http verb GET")

--- a/src/main/kotlin/it/skrape/core/fetcher/Fetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/Fetcher.kt
@@ -1,0 +1,7 @@
+package it.skrape.core.fetcher
+
+import it.skrape.core.Result
+
+interface Fetcher {
+	fun fetch(): Result
+}

--- a/src/main/kotlin/it/skrape/core/fetcher/HttpFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/HttpFetcher.kt
@@ -2,12 +2,11 @@ package it.skrape.core.fetcher
 
 import it.skrape.core.Request
 import it.skrape.core.Result
-import org.jsoup.Connection
 import org.jsoup.Jsoup
 
-internal class HttpFetcher(private val request: Request) {
+internal class HttpFetcher(private val request: Request): Fetcher {
 
-    fun fetch(): Result {
+    override fun fetch(): Result {
 
         val connection = Jsoup.connect(request.url)
                 .method(request.method)
@@ -33,5 +32,3 @@ internal class HttpFetcher(private val request: Request) {
         )
     }
 }
-
-typealias Response = Connection.Response

--- a/src/main/kotlin/it/skrape/core/fetcher/KoFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/KoFetcher.kt
@@ -1,0 +1,50 @@
+package it.skrape.core.fetcher
+
+import io.github.rybalkinsd.kohttp.client.defaultHttpClient
+import io.github.rybalkinsd.kohttp.client.fork
+import io.github.rybalkinsd.kohttp.dsl.*
+import io.github.rybalkinsd.kohttp.dsl.context.HttpContext
+import io.github.rybalkinsd.kohttp.ext.url
+import it.skrape.core.Request
+import it.skrape.core.Result
+import org.jsoup.Connection
+
+class KoFetcher(private val request: Request): Fetcher {
+	private val client = defaultHttpClient.fork {
+		followRedirects = request.followRedirects
+		readTimeout = request.timeout.toLong()
+	}
+
+	override fun fetch(): Result {
+		val requester = when(request.method) {
+			Connection.Method.GET -> httpGet(client, getContext())
+			Connection.Method.POST -> httpPost(client, getContext())
+			Connection.Method.PUT -> httpPut(client, getContext())
+			Connection.Method.DELETE -> httpDelete(client, getContext())
+			Connection.Method.PATCH -> httpPatch(client, getContext())
+			Connection.Method.HEAD -> httpHead(client, getContext())
+			else -> throw UnsupportedOperationException("Method is not supported by KoHttp")
+		}
+		requester.use {
+			return Result(
+				responseBody = it.body()?.string() ?: "",
+				statusCode = it.code(),
+				statusMessage = it.message(),
+				contentType = it.header("Content-Type"),
+				headers = it.headers().names().associateBy({item -> item}, {item -> it.header(item, "")!!}),
+				request = request
+			)
+		}
+	}
+
+	private fun getContext(): HttpContext.() -> Unit = {
+		url(request.url)
+		header {
+			request.headers
+			"User-Agent" to request.userAgent
+			cookie {
+				request.cookies
+			}
+		}
+	}
+}

--- a/src/main/kotlin/it/skrape/core/fetcher/KoFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/KoFetcher.kt
@@ -10,13 +10,14 @@ import it.skrape.core.Result
 import org.jsoup.Connection
 
 class KoFetcher(private val request: Request): Fetcher {
+	// create a new client using our custom options
 	private val client = defaultHttpClient.fork {
 		followRedirects = request.followRedirects
 		readTimeout = request.timeout.toLong()
 	}
 
 	override fun fetch(): Result {
-		val requester = when(request.method) {
+		when(request.method) {
 			Connection.Method.GET -> httpGet(client, getContext())
 			Connection.Method.POST -> httpPost(client, getContext())
 			Connection.Method.PUT -> httpPut(client, getContext())
@@ -24,8 +25,8 @@ class KoFetcher(private val request: Request): Fetcher {
 			Connection.Method.PATCH -> httpPatch(client, getContext())
 			Connection.Method.HEAD -> httpHead(client, getContext())
 			else -> throw UnsupportedOperationException("Method is not supported by KoHttp")
-		}
-		requester.use {
+		}.use {
+			// assemble the result from the response data
 			return Result(
 				responseBody = it.body()?.string() ?: "",
 				statusCode = it.code(),

--- a/src/test/kotlin/it/skrape/DslTest.kt
+++ b/src/test/kotlin/it/skrape/DslTest.kt
@@ -198,7 +198,7 @@ internal class DslTest : WireMockSetup() {
         wireMockServer.setupStub()
 
         skrape {
-            url = "http://localhost:8080"
+            url = "http://localhost:8080/"
 
             val extracted = extract {
                 MyObject(statusMessage, "", emptyList())
@@ -213,7 +213,7 @@ internal class DslTest : WireMockSetup() {
         wireMockServer.setupStub()
 
         skrape {
-            url = "http://localhost:8080"
+            url = "http://localhost:8080/"
 
             val extracted = extract {
                 MyObject(statusMessage, "", emptyList())
@@ -228,7 +228,7 @@ internal class DslTest : WireMockSetup() {
         wireMockServer.setupStub()
 
         val extracted = skrape {
-            url = "http://localhost:8080"
+            url = "http://localhost:8080/"
 
             extractIt<MyOtherObject> {
                 it.message = statusMessage
@@ -257,7 +257,7 @@ internal class DslTest : WireMockSetup() {
         wireMockServer.setupStub()
 
         val extracted = skrape {
-            url = "http://localhost:8080"
+            url = "http://localhost:8080/"
 
             extract {
                 htmlDocument {

--- a/src/test/kotlin/it/skrape/core/fetcher/KoFetcherTest.kt
+++ b/src/test/kotlin/it/skrape/core/fetcher/KoFetcherTest.kt
@@ -23,6 +23,23 @@ internal class KoFetcherTest : WireMockSetup() {
         assertThat(fetched.document.title()).isEqualTo("i'm the title")
     }
 
+	@Test
+	internal fun `will set correct headers`() {
+		val ua = "test user agent"
+
+		// given
+		wireMockServer.setupStub()
+		val options = Request().apply {
+			userAgent = ua
+			headers = mapOf("Content-Type" to "application/json")
+		}
+
+		// when
+		val fetched = KoFetcher(options).fetch()
+		assertThat(fetched.request.userAgent).isEqualTo(ua)
+		assertThat(fetched.request.headers.size).isEqualTo(1)
+	}
+
     @Test
     internal fun `can fetch url and use HTTP verb GET by default`() {
         // given

--- a/src/test/kotlin/it/skrape/core/fetcher/KoFetcherTest.kt
+++ b/src/test/kotlin/it/skrape/core/fetcher/KoFetcherTest.kt
@@ -1,0 +1,110 @@
+package it.skrape.core.fetcher
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import it.skrape.core.*
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.net.SocketTimeoutException
+
+internal class KoFetcherTest : WireMockSetup() {
+
+    @Test
+    internal fun `will fetch localhost 8080 with defaults if no params`() {
+        // given
+        wireMockServer.setupStub()
+
+        // when
+        val fetched = KoFetcher(Request()).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(200)
+        assertThat(fetched.contentType).isEqualTo("text/html;charset=utf-8")
+        assertThat(fetched.document.title()).isEqualTo("i'm the title")
+    }
+
+    @Test
+    internal fun `can fetch url and use HTTP verb GET by default`() {
+        // given
+        wireMockServer.setupStub(path = "/example")
+        val options = Request().apply {
+            url = "http://localhost:8080/example"
+        }
+
+        // when
+        val fetched = KoFetcher(options).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(200)
+        assertThat(fetched.contentType).isEqualTo("text/html;charset=utf-8")
+        assertThat(fetched.document.title()).isEqualTo("i'm the title")
+    }
+
+    @Test
+    internal fun `will not throw exception on non existing url`() {
+        // given
+        val options = Request().apply {
+            url = "http://localhost:8080/not-existing"
+        }
+
+        // when
+        val fetched = KoFetcher(options).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(404)
+    }
+
+    @Test
+    internal fun `will not follow redirects if configured`() {
+        // given
+        wireMockServer.setupRedirect()
+        val options = Request().apply {
+            followRedirects = false
+        }
+
+        // when
+        val fetched = KoFetcher(options).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(302)
+    }
+
+    @Test
+    internal fun `will follow redirect by default`() {
+        // given
+        wireMockServer.setupRedirect()
+
+        // when
+        val fetched = KoFetcher(Request()).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(404)
+    }
+
+    @Test
+    internal fun `can fetch url and use HTTP verb POST`() {
+        // given
+        wireMockServer.setupPostStub()
+        val options = Request().apply {
+            method = Method.POST
+        }
+
+        // when
+        val fetched = KoFetcher(options).fetch()
+
+        // then
+        assertThat(fetched.statusCode).isEqualTo(200)
+        assertThat(fetched.contentType).isEqualTo("application/json;charset=utf-8")
+        assertThat(fetched.responseBody).isEqualTo("""{"data":"some value"}""")
+    }
+
+    @Test
+    internal fun `will throw exception on timeout`() {
+        wireMockServer.setupStub(delay = 6000)
+
+        assertThrows(SocketTimeoutException::class.java
+        ) {
+            KoFetcher(Request()).fetch()
+        }
+    }
+}


### PR DESCRIPTION
Adds KoHttp as an HTTP client.

Note: there are issues with self-signed certificates when using Java 9+ due to changes made to the default key/trust store.