### PR TITLE
Unify `selects` package document hierarchy to allow for nested queries

### DIFF
--- a/src/main/kotlin/it/skrape/selects/CssSelectable.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelectable.kt
@@ -16,7 +16,7 @@ abstract class CssSelectable {
 
     /**
      * Will create a CssSelector scope to calculate a css selector
-     * @param cssSelector that represents an CSS-Selector that will be considered during calculation
+     * @param init block for configuring the CSS-Selector that will be considered during calculation
      * @return T
      */
     operator fun <T> String.invoke(init: CssSelector.() -> T) =
@@ -74,7 +74,7 @@ abstract class CssSelectable {
      * @return T
      */
     fun <T> findAll(cssSelector: String = "", init: List<DocElement>.() -> T) =
-            this.findAll(cssSelector).init()
+            findAll(cssSelector).init()
 
     fun <T> findByIndex(index: Int, cssSelector: String = "", init: DocElement.() -> T) =
             findByIndex(index, cssSelector).init()

--- a/src/main/kotlin/it/skrape/selects/CssSelectable.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelectable.kt
@@ -7,6 +7,8 @@ import java.util.*
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
 abstract class CssSelectable {
+    abstract val toCssSelector: String
+
     internal abstract fun applySelector(rawCssSelector: String): List<DocElement>
 
     fun <T> selection(cssSelector: String, init: CssSelector.() -> T) =

--- a/src/main/kotlin/it/skrape/selects/CssSelectable.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelectable.kt
@@ -1,0 +1,104 @@
+package it.skrape.selects
+
+import it.skrape.SkrapeItDsl
+import org.jsoup.nodes.Element
+import java.util.*
+
+@Suppress("TooManyFunctions")
+@SkrapeItDsl
+abstract class CssSelectable {
+    internal abstract fun applySelector(rawCssSelector: String): List<DocElement>
+
+    fun <T> selection(cssSelector: String, init: CssSelector.() -> T) =
+            CssSelector(rawCssSelector = cssSelector, doc = this).init()
+
+    /**
+     * Will create a CssSelector scope to calculate a css selector
+     * @param cssSelector that represents an CSS-Selector that will be considered during calculation
+     * @return T
+     */
+    operator fun <T> String.invoke(init: CssSelector.() -> T) =
+            this@CssSelectable.selection(this, init)
+
+    open fun makeDefault(cssSelector: String): DocElement {
+        return DocElement(Element("${UUID.randomUUID()}"))
+    }
+
+    /**
+     * Will pick all occurrences of elements that are matching the CSS-Selector
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    infix fun findAll(cssSelector: String): List<DocElement> =
+            this.applySelector(cssSelector)
+
+    fun findByIndex(index: Int, cssSelector: String = ""): DocElement =
+            findAll(cssSelector).getOrElse(index) { makeDefault(cssSelector) }
+
+    operator fun Int.invoke(cssSelector: String = ""): DocElement =
+            findByIndex(this, cssSelector)
+
+    /**
+     * Will pick the first occurrence of an element that
+     * is matching the CSS-Selector from a parsed document and invoke it to a lambda function.
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    infix fun findFirst(cssSelector: String): DocElement =
+            findByIndex(0, cssSelector)
+
+    fun findSecond(cssSelector: String = ""): DocElement =
+            findByIndex(1, cssSelector)
+
+    fun findThird(cssSelector: String = ""): DocElement =
+            findByIndex(2, cssSelector)
+
+    fun findLast(cssSelector: String = ""): DocElement {
+        val index = findAll(cssSelector).lastIndex
+        return findByIndex(index, cssSelector)
+    }
+
+    fun findSecondLast(cssSelector: String = ""): DocElement {
+        val index = findAll(cssSelector).lastIndex - 1
+        return findByIndex(index, cssSelector)
+    }
+
+    /**
+     * Will pick all occurrences of elements that are matching the CSS-Selector
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    fun <T> findAll(cssSelector: String = "", init: List<DocElement>.() -> T) =
+            this.findAll(cssSelector).init()
+
+    fun <T> findByIndex(index: Int, cssSelector: String = "", init: DocElement.() -> T) =
+            findByIndex(index, cssSelector).init()
+
+    operator fun <T> Int.invoke(cssSelector: String = "", init: DocElement.() -> T) =
+            this(cssSelector).init()
+
+    /**
+     * Will pick the first occurrence of an element that
+     * is matching the CSS-Selector from a parsed document and invoke it to a lambda function.
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    fun <T> findFirst(cssSelector: String = "", init: DocElement.() -> T) =
+            findFirst(cssSelector).init()
+
+    fun <T> findSecond(cssSelector: String = "", init: DocElement.() -> T) =
+            findSecond(cssSelector).init()
+
+    fun <T> findThird(cssSelector: String = "", init: DocElement.() -> T) =
+            findThird(cssSelector).init()
+
+    fun <T> findLast(cssSelector: String = "", init: DocElement.() -> T) =
+            findLast(cssSelector).init()
+
+    fun <T> findSecondLast(cssSelector: String = "", init: DocElement.() -> T) =
+            findSecondLast(cssSelector).init()
+}

--- a/src/main/kotlin/it/skrape/selects/CssSelector.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelector.kt
@@ -15,12 +15,15 @@ class CssSelector(
         var withAttributes: List<Pair<String, String>>? = null,
         val doc: CssSelectable = Doc(Document(""))
 ) : CssSelectable() {
+    override val toCssSelector: String
+        get() = "${doc.toCssSelector} $ownCssSelector".trim()
+
     override fun applySelector(rawCssSelector: String): List<DocElement> {
-        val combinedSelector = "$toCssSelector $rawCssSelector".trim()
+        val combinedSelector = "$ownCssSelector $rawCssSelector".trim()
         return doc.applySelector(combinedSelector)
     }
 
-    val toCssSelector: String
+    val ownCssSelector: String
         get() {
             val calculatedSelector =
                     withId.toIdSelector().orEmpty() +

--- a/src/main/kotlin/it/skrape/selects/CssSelector.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelector.kt
@@ -15,7 +15,7 @@ class CssSelector(
         var withAttributeKeys: List<String>? = null,
         var withAttribute: Pair<String, String>? = null,
         var withAttributes: List<Pair<String, String>>? = null,
-        val doc: Doc = Doc(Document(""))
+        val doc: DomTreeElement = Doc(Document(""))
 ) {
 
     fun <T> findByIndex(index: Int, init: DocElement.() -> T): T {
@@ -28,7 +28,6 @@ class CssSelector(
 
     fun <T> findFirst(init: DocElement.() -> T): T =
             findByIndex(0, init)
-
 
     fun <T> findSecond(init: DocElement.() -> T): T =
             findByIndex(1, init)

--- a/src/main/kotlin/it/skrape/selects/CssSelector.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelector.kt
@@ -2,8 +2,6 @@ package it.skrape.selects
 
 import it.skrape.SkrapeItDsl
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
-import java.util.*
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
@@ -15,37 +13,12 @@ class CssSelector(
         var withAttributeKeys: List<String>? = null,
         var withAttribute: Pair<String, String>? = null,
         var withAttributes: List<Pair<String, String>>? = null,
-        val doc: DomTreeElement = Doc(Document(""))
-) {
-
-    fun <T> findByIndex(index: Int, init: DocElement.() -> T): T {
-        val all = findAll { this }
-        return if (all.isEmpty()) DocElement(Element("${UUID.randomUUID()}")).init() else all[index].init()
+        val doc: CssSelectable = Doc(Document(""))
+) : CssSelectable() {
+    override fun applySelector(rawCssSelector: String): List<DocElement> {
+        val combinedSelector = "$toCssSelector $rawCssSelector".trim()
+        return doc.applySelector(combinedSelector)
     }
-
-    operator fun <T> Int.invoke(init: DocElement.() -> T) =
-            findByIndex(this, init)
-
-    fun <T> findFirst(init: DocElement.() -> T): T =
-            findByIndex(0, init)
-
-    fun <T> findSecond(init: DocElement.() -> T): T =
-            findByIndex(1, init)
-
-    fun <T> findThird(init: DocElement.() -> T): T =
-            findByIndex(2, init)
-
-    fun <T> findLast(init: DocElement.() -> T): T {
-        val index = findAll { this }.size - 1
-        return findByIndex(index, init)
-    }
-
-    fun <T> findSecondLast(init: DocElement.() -> T): T {
-        val index = findAll { this }.size - 2
-        return findByIndex(index, init)
-    }
-
-    fun <T> findAll(init: List<DocElement>.() -> T) = doc.findAll(toCssSelector, init)
 
     val toCssSelector: String
         get() {
@@ -76,9 +49,6 @@ class CssSelector(
             this?.joinToString(separator = "") { "[${it.first}='${it.second}']" }
 
     private fun String.withoutSpaces() = replace("\\s".toRegex(), "")
-
-    operator fun <T> String.invoke(init: CssSelector.() -> T) =
-            CssSelector(rawCssSelector = "${this@CssSelector.toCssSelector} $this").init()
 }
 
 typealias CssClassName = String

--- a/src/main/kotlin/it/skrape/selects/CssSelector.kt
+++ b/src/main/kotlin/it/skrape/selects/CssSelector.kt
@@ -3,7 +3,6 @@ package it.skrape.selects
 import it.skrape.SkrapeItDsl
 import org.jsoup.nodes.Document
 
-@Suppress("TooManyFunctions")
 @SkrapeItDsl
 class CssSelector(
         var rawCssSelector: String = "",

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -12,17 +12,6 @@ class Doc(val document: Document, var relaxed: Boolean = false): DomTreeElement(
         get() = this.document
 
     /**
-     * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.
-     * For example, given HTML {@code <p>Hello  <b>there</b> now! </p>} returns {@code "Hello there now!"}
-     *
-     * @return unencoded, normalized text, or empty string if none.
-     * @see wholeText if you don't want the text to be normalized.
-     * @see #ownText()
-     * @see #textNodes()
-     */
-    val text by lazy { document.text().orEmpty() }
-
-    /**
      * Get the (unencoded) text of all children of this element, including any newlines and spaces present in the
      * original.
      *
@@ -31,55 +20,20 @@ class Doc(val document: Document, var relaxed: Boolean = false): DomTreeElement(
      */
     val wholeText by lazy { document.wholeText().orEmpty() }
 
-    /**
-     * Retrieves the element's inner HTML. E.g. on a {@code <div>} with one empty {@code <p>}, would return
-     * {@code <p></p>}. (Whereas {@link outerHtml} would return {@code <div><p></p></div>}.)
-     * @return String of HTML.
-     * @see outerHtml
-     */
-    val html: String by lazy { document.html().orEmpty() }
-
-    /**
-     * Get the outer HTML of this node. For example, on a {@code p} element, may return {@code <p>Para</p>}.
-     * @return outer HTML
-     * @see html
-     * @see text
-     */
-    val outerHtml: String by lazy { document.outerHtml().orEmpty() }
+    val titleText by lazy { document.title().orEmpty() }
 
     /**
      * Find all elements in the document.
      * @return List<DocElement>
      */
-    val allElements by lazy { document.allElements.map { DocElement(it) } }
+    override val allElements by lazy { document.allElements.map { DocElement(it) } }
 
-    /**
-     * Find all elements in the document.
-     * @return T
-     */
-    fun <T> findAll(init: List<DocElement>.() -> T): T = allElements.init()
-
-    infix fun findAll(cssSelector: String): List<DocElement> {
+    override infix fun findAll(cssSelector: String): List<DocElement> {
         val selected = document.select(cssSelector)
                 .map { DocElement(it) }
                 .takeIf { it.isNotEmpty() }
         return if (relaxed) selected.orEmpty() else selected ?: throw ElementNotFoundException(cssSelector)
     }
 
-    fun <T> findAll(cssSelector: String, init: List<DocElement>.() -> T) = findAll(cssSelector).init()
-
-    infix fun findFirst(cssSelector: String) = findAll(cssSelector).firstOrNull() ?: DocElement(Element(cssSelector))
-
-    fun <T> findFirst(cssSelector: String, init: DocElement.() -> T) = findFirst(cssSelector).init()
-
-    val titleText = document.title().orEmpty()
-
-    override fun toString() = document.toString()
-
-    operator fun <T> String.invoke(init: CssSelector.() -> T) =
-            this@Doc.selection(this, init)
-
-    fun <T> selection(cssSelector: String, init: CssSelector.() -> T) =
-            CssSelector(rawCssSelector = cssSelector, doc = this).init()
-
+    override infix fun findFirst(cssSelector: String) = findAll(cssSelector).firstOrNull() ?: DocElement(Element(cssSelector))
 }

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -25,9 +25,8 @@ class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement
     override val toCssSelector: String = ""
 
     override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
-        val selected = document.select(rawCssSelector)
-                .map { DocElement(it) }
-                .takeIf { it.isNotEmpty() }
+        val queried = document.allElements.select(rawCssSelector).map { DocElement(it) }
+        val selected = queried.takeIf { it.isNotEmpty() }
         return if (relaxed) selected.orEmpty() else selected ?: throw ElementNotFoundException(rawCssSelector)
     }
 

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -22,6 +22,8 @@ class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement
 
     val titleText by lazy { document.title().orEmpty() }
 
+    override val toCssSelector: String = ""
+
     /**
      * Find all elements in the document.
      * @return List<DocElement>

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -7,7 +7,7 @@ import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class Doc(val document: Document, var relaxed: Boolean = false): DomTreeElement() {
+class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement() {
     override val element: Element
         get() = this.document
 
@@ -28,12 +28,14 @@ class Doc(val document: Document, var relaxed: Boolean = false): DomTreeElement(
      */
     override val allElements by lazy { document.allElements.map { DocElement(it) } }
 
-    override infix fun findAll(cssSelector: String): List<DocElement> {
-        val selected = document.select(cssSelector)
+    override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
+        val selected = document.select(rawCssSelector)
                 .map { DocElement(it) }
                 .takeIf { it.isNotEmpty() }
-        return if (relaxed) selected.orEmpty() else selected ?: throw ElementNotFoundException(cssSelector)
+        return if (relaxed) selected.orEmpty() else selected ?: throw ElementNotFoundException(rawCssSelector)
     }
 
-    override infix fun findFirst(cssSelector: String) = findAll(cssSelector).firstOrNull() ?: DocElement(Element(cssSelector))
+    override fun makeDefault(cssSelector: String): DocElement {
+        return DocElement(Element(cssSelector))
+    }
 }

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -7,7 +7,9 @@ import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class Doc(val document: Document, var relaxed: Boolean = false) {
+class Doc(val document: Document, var relaxed: Boolean = false): DomTreeElement() {
+    override val element: Element
+        get() = this.document
 
     /**
      * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -7,7 +7,7 @@ import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement() {
+class Doc(val document: Document, override var relaxed: Boolean = false) : DomTreeElement() {
     override val element: Element
         get() = this.document
 
@@ -24,13 +24,7 @@ class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement
 
     override val toCssSelector: String = ""
 
-    override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
-        val queried = document.allElements.select(rawCssSelector).map { DocElement(it) }
-        val selected = queried.takeIf { it.isNotEmpty() }
-        return if (relaxed) selected.orEmpty() else selected ?: throw ElementNotFoundException(rawCssSelector)
-    }
-
-    override fun makeDefault(cssSelector: String): DocElement {
-        return DocElement(Element(cssSelector))
+    override fun makeDefaultElement(cssSelector: String): DocElement {
+        return DocElement(Element(cssSelector), relaxed)
     }
 }

--- a/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -24,12 +24,6 @@ class Doc(val document: Document, var relaxed: Boolean = false) : DomTreeElement
 
     override val toCssSelector: String = ""
 
-    /**
-     * Find all elements in the document.
-     * @return List<DocElement>
-     */
-    override val allElements by lazy { document.allElements.map { DocElement(it) } }
-
     override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
         val selected = document.select(rawCssSelector)
                 .map { DocElement(it) }

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -88,9 +88,6 @@ class DocElement(override val element: Element): DomTreeElement() {
 
     override fun toRawCssSelector() = "$cssSelector $this"
 
-    val toDoc: Doc
-        get() = htmlDocument(html)
-
     @Deprecated("use 'findAll(cssSelector: String) instead'")
     fun select(cssSelector: String) = element.select(cssSelector).map { DocElement(it) }
 }

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -5,7 +5,9 @@ import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class DocElement(override val element: Element) : DomTreeElement() {
+class DocElement internal constructor(override val element: Element, override val relaxed: Boolean) : DomTreeElement() {
+    constructor(element: Element) : this(element, false)
+
     /**
      * Get the name of the tag for this element. E.g. {@code div}.
      *
@@ -63,12 +65,8 @@ class DocElement(override val element: Element) : DomTreeElement() {
     override val toCssSelector: String
         get() = cssSelector
 
-    override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
-        return element.children().select(rawCssSelector).map { DocElement(it) }
-    }
-
     @Deprecated("use 'findAll(cssSelector: String) instead'", ReplaceWith("findAll(cssSelector)"))
-    fun select(cssSelector: String) = element.select(cssSelector).map { DocElement(it) }
+    fun select(cssSelector: String) = element.select(cssSelector).map { DocElement(it, relaxed) }
 }
 
 val List<DocElement>.text

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -15,18 +15,6 @@ class DocElement(override val element: Element): DomTreeElement() {
     val tagName by lazy { element.tagName().orEmpty() }
 
     /**
-     * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.
-     * <p>
-     * For example, given HTML {@code <p>Hello <b>there</b> now! </p>}, {@code p.text()} returns {@code "Hello there now!"}
-     *
-     * @return unencoded, normalized text, or empty string if none.
-     * @see #wholeText() if you don't want the text to be normalized.
-     * @see #ownText()
-     * @see #textNodes()
-     */
-    val text by lazy { element.text().orEmpty() }
-
-    /**
      * Gets the text owned by this element only; does not get the combined text of all children.
      * For example, given HTML {@code <p>Hello <b>there</b> now!</p>}, {@code p.ownText()} returns {@code "Hello now!"},
      * whereas {@code text} returns {@code "Hello there now!"}.
@@ -38,28 +26,10 @@ class DocElement(override val element: Element): DomTreeElement() {
     val ownText by lazy { element.ownText().orEmpty() }
 
     /**
-     * Retrieves the element's inner HTML. E.g. on a {@code <div>} with one empty {@code <p>}, would return
-     * {@code <p></p>}. (Whereas {@link #outerHtml()} would return {@code <div><p></p></div>}.)
-     *
-     * @return String of HTML.
-     * @see outerHtml
-     * @see text
-     */
-    val html by lazy { element.html().orEmpty() }
-
-    /**
-     * Get the outer HTML of this node. For example, on a {@code p} element, may return {@code <p>Para</p>}.
-     * @return outer HTML
-     * @see html
-     * @see text
-     */
-    val outerHtml by lazy { element.outerHtml().orEmpty() }
-
-    /**
      * Find all elements under this element (including self, and children of children).
      * @return List<DocElement>
      */
-    val allElements by lazy { element.allElements.map { DocElement(it) } }
+    override val allElements by lazy { element.allElements.map { DocElement(it) } }
 
     /**
      * Get all of the element's attributes.
@@ -98,37 +68,13 @@ class DocElement(override val element: Element): DomTreeElement() {
     val cssSelector by lazy { element.cssSelector().orEmpty() }
 
     /**
-     * Find all elements under this element (including self, and children of children).
-     * @return T
-     */
-    fun <T> findAll(init: List<DocElement>.() -> T): T = allElements.init()
-
-    /**
-     * Will pick all occurrences of elements that are matching the CSS-Selector
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return T
-     */
-    fun <T> findAll(cssSelector: String, init: List<DocElement>.() -> T): T =
-            findAll(cssSelector).init()
-
-    /**
      * Will pick all occurrences of elements that are matching the CSS-Selector and return it as List<DocElement>.
      * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
      * @param cssSelector that represents an CSS-Selector
      * @return List<DocElement>
      */
-    infix fun findAll(cssSelector: String): List<DocElement> =
+    override infix fun findAll(cssSelector: String): List<DocElement> =
             element.allElements.select(cssSelector).map { DocElement(it) }
-
-    /**
-     * Will pick the first occurrence of an element that
-     * is matching the CSS-Selector from a parsed document and invoke it to a lambda function.
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return T
-     */
-    fun <T> findFirst(cssSelector: String, init: DocElement.() -> T): T = findFirst(cssSelector).init()
 
     /**
      * Will pick the first occurrence of an element that
@@ -137,17 +83,10 @@ class DocElement(override val element: Element): DomTreeElement() {
      * @param cssSelector that represents an CSS-Selector
      * @return DocElement
      */
-    infix fun findFirst(cssSelector: String): DocElement = findAll(cssSelector)[0]
+    override infix fun findFirst(cssSelector: String): DocElement =
+            findAll(cssSelector)[0]
 
-    /**
-     * Will create a CssSelector scope to calculate a css selector
-     * @param cssSelector that represents an CSS-Selector that will be considered during calculation
-     * @return T
-     */
-    operator fun <T> String.invoke(init: CssSelector.() -> T) =
-            CssSelector(rawCssSelector = "$cssSelector $this").init()
-
-    override fun toString() = element.toString()
+    override fun toRawCssSelector() = "$cssSelector $this"
 
     val toDoc: Doc
         get() = htmlDocument(html)

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -25,12 +25,6 @@ class DocElement(override val element: Element) : DomTreeElement() {
     val ownText by lazy { element.ownText().orEmpty() }
 
     /**
-     * Find all elements under this element (including self, and children of children).
-     * @return List<DocElement>
-     */
-    override val allElements by lazy { element.allElements.map { DocElement(it) } }
-
-    /**
      * Get all of the element's attributes.
      * @return Map<String, String>> of attribute key value pairs
      */
@@ -69,11 +63,8 @@ class DocElement(override val element: Element) : DomTreeElement() {
     override val toCssSelector: String
         get() = cssSelector
 
-    val ownCssSelector by lazy { cssSelector.split("\\s+".toRegex()).lastOrNull().orEmpty() }
-
     override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
-        val combinedSelector = "$ownCssSelector $rawCssSelector".trim()
-        return element.allElements.select(combinedSelector).map { DocElement(it) }
+        return element.children().select(rawCssSelector).map { DocElement(it) }
     }
 
     @Deprecated("use 'findAll(cssSelector: String) instead'", ReplaceWith("findAll(cssSelector)"))

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -66,8 +66,13 @@ class DocElement(override val element: Element) : DomTreeElement() {
 
     val cssSelector by lazy { element.cssSelector().orEmpty() }
 
+    override val toCssSelector: String
+        get() = cssSelector
+
+    val ownCssSelector by lazy { cssSelector.split("\\s+".toRegex()).lastOrNull().orEmpty() }
+
     override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
-        val combinedSelector = "$cssSelector $rawCssSelector".trim()
+        val combinedSelector = "$ownCssSelector $rawCssSelector".trim()
         return element.allElements.select(combinedSelector).map { DocElement(it) }
     }
 

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -2,13 +2,11 @@ package it.skrape.selects
 
 import it.skrape.SkrapeItDsl
 import it.skrape.core.htmlDocument
-import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class DocElement(private val element: Element) {
-
+class DocElement(override val element: Element): DomTreeElement() {
     /**
      * Get the name of the tag for this element. E.g. {@code div}.
      *

--- a/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -1,12 +1,11 @@
 package it.skrape.selects
 
 import it.skrape.SkrapeItDsl
-import it.skrape.core.htmlDocument
 import org.jsoup.nodes.Element
 
 @Suppress("TooManyFunctions")
 @SkrapeItDsl
-class DocElement(override val element: Element): DomTreeElement() {
+class DocElement(override val element: Element) : DomTreeElement() {
     /**
      * Get the name of the tag for this element. E.g. {@code div}.
      *
@@ -67,28 +66,12 @@ class DocElement(override val element: Element): DomTreeElement() {
 
     val cssSelector by lazy { element.cssSelector().orEmpty() }
 
-    /**
-     * Will pick all occurrences of elements that are matching the CSS-Selector and return it as List<DocElement>.
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return List<DocElement>
-     */
-    override infix fun findAll(cssSelector: String): List<DocElement> =
-            element.allElements.select(cssSelector).map { DocElement(it) }
+    override fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement> {
+        val combinedSelector = "$cssSelector $rawCssSelector".trim()
+        return element.allElements.select(combinedSelector).map { DocElement(it) }
+    }
 
-    /**
-     * Will pick the first occurrence of an element that
-     * is matching the CSS-Selector from a parsed document.
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return DocElement
-     */
-    override infix fun findFirst(cssSelector: String): DocElement =
-            findAll(cssSelector)[0]
-
-    override fun toRawCssSelector() = "$cssSelector $this"
-
-    @Deprecated("use 'findAll(cssSelector: String) instead'")
+    @Deprecated("use 'findAll(cssSelector: String) instead'", ReplaceWith("findAll(cssSelector)"))
     fun select(cssSelector: String) = element.select(cssSelector).map { DocElement(it) }
 }
 
@@ -116,5 +99,3 @@ fun <T> List<DocElement>.forEachLink(init: (text: String, url: String) -> T) {
 
 val List<DocElement>.eachHrefAsAbsoluteLink
     get(): List<String> = this eachAttribute "abs:href"
-
-// fun <T> List<DocElement>.findFirst(init: DocElement.() -> T): T = this[0].init()

--- a/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -1,0 +1,7 @@
+package it.skrape.selects
+
+import org.jsoup.nodes.Element
+
+abstract class DomTreeElement {
+    protected abstract val element: Element
+}

--- a/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -33,7 +33,11 @@ abstract class DomTreeElement : CssSelectable() {
      */
     val outerHtml: String by lazy { element.outerHtml().orEmpty() }
 
-    abstract val allElements: List<DocElement>
+    /**
+     * Find all elements in the document.
+     * @return List<DocElement>
+     */
+    val allElements by lazy { element.allElements.map { DocElement(it) } }
 
     abstract fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement>
 

--- a/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -3,5 +3,77 @@ package it.skrape.selects
 import org.jsoup.nodes.Element
 
 abstract class DomTreeElement {
-    protected abstract val element: Element
+    abstract val element: Element
+
+    /**
+     * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.
+     * <p>
+     * For example, given HTML {@code <p>Hello <b>there</b> now! </p>}, {@code p.text()} returns {@code "Hello there now!"}
+     *
+     * @return unencoded, normalized text, or empty string if none.
+     * @see #wholeText() if you don't want the text to be normalized.
+     * @see #ownText()
+     * @see #textNodes()
+     */
+    val text by lazy { element.text().orEmpty() }
+
+    /**
+     * Retrieves the element's inner HTML. E.g. on a {@code <div>} with one empty {@code <p>}, would return
+     * {@code <p></p>}. (Whereas {@link outerHtml} would return {@code <div><p></p></div>}.)
+     * @return String of HTML.
+     * @see outerHtml
+     */
+    val html: String by lazy { element.html().orEmpty() }
+
+    /**
+     * Get the outer HTML of this node. For example, on a {@code p} element, may return {@code <p>Para</p>}.
+     * @return outer HTML
+     * @see html
+     * @see text
+     */
+    val outerHtml: String by lazy { element.outerHtml().orEmpty() }
+
+    abstract val allElements: List<DocElement>
+
+    /**
+     * Find all elements in the document.
+     * @return T
+     */
+    fun <T> findAll(init: List<DocElement>.() -> T): T = allElements.init()
+
+    abstract fun findAll(cssSelector: String): List<DocElement>
+
+    /**
+     * Will pick all occurrences of elements that are matching the CSS-Selector
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    fun <T> findAll(cssSelector: String, init: List<DocElement>.() -> T) = findAll(cssSelector).init()
+
+    abstract fun findFirst(cssSelector: String): DocElement
+
+    /**
+     * Will pick the first occurrence of an element that
+     * is matching the CSS-Selector from a parsed document and invoke it to a lambda function.
+     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
+     * @param cssSelector that represents an CSS-Selector
+     * @return T
+     */
+    fun <T> findFirst(cssSelector: String, init: DocElement.() -> T): T = findFirst(cssSelector).init()
+
+    fun <T> selection(cssSelector: String, init: CssSelector.() -> T) =
+            CssSelector(rawCssSelector = cssSelector, doc = this).init()
+
+    protected open fun toRawCssSelector(): String = this.toString()
+
+    /**
+     * Will create a CssSelector scope to calculate a css selector
+     * @param cssSelector that represents an CSS-Selector that will be considered during calculation
+     * @return T
+     */
+    operator fun <T> String.invoke(init: CssSelector.() -> T) =
+            this@DomTreeElement.selection(this@DomTreeElement.toRawCssSelector(), init)
+
+    override fun toString() = element.toString()
 }

--- a/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -2,7 +2,7 @@ package it.skrape.selects
 
 import org.jsoup.nodes.Element
 
-abstract class DomTreeElement {
+abstract class DomTreeElement : CssSelectable() {
     abstract val element: Element
 
     /**
@@ -35,45 +35,15 @@ abstract class DomTreeElement {
 
     abstract val allElements: List<DocElement>
 
-    /**
-     * Find all elements in the document.
-     * @return T
-     */
-    fun <T> findAll(init: List<DocElement>.() -> T): T = allElements.init()
+    abstract fun applyNonTrivialSelector(rawCssSelector: String): List<DocElement>
 
-    abstract fun findAll(cssSelector: String): List<DocElement>
+    override fun applySelector(rawCssSelector: String): List<DocElement> {
+        if (rawCssSelector.isEmpty()) {
+            return allElements
+        }
 
-    /**
-     * Will pick all occurrences of elements that are matching the CSS-Selector
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return T
-     */
-    fun <T> findAll(cssSelector: String, init: List<DocElement>.() -> T) = findAll(cssSelector).init()
-
-    abstract fun findFirst(cssSelector: String): DocElement
-
-    /**
-     * Will pick the first occurrence of an element that
-     * is matching the CSS-Selector from a parsed document and invoke it to a lambda function.
-     * @see <a href="https://www.w3schools.com/cssref/css_selectors.asp">Overview of CSS-Selectors for further information.</a>
-     * @param cssSelector that represents an CSS-Selector
-     * @return T
-     */
-    fun <T> findFirst(cssSelector: String, init: DocElement.() -> T): T = findFirst(cssSelector).init()
-
-    fun <T> selection(cssSelector: String, init: CssSelector.() -> T) =
-            CssSelector(rawCssSelector = cssSelector, doc = this).init()
-
-    protected open fun toRawCssSelector(): String = this.toString()
-
-    /**
-     * Will create a CssSelector scope to calculate a css selector
-     * @param cssSelector that represents an CSS-Selector that will be considered during calculation
-     * @return T
-     */
-    operator fun <T> String.invoke(init: CssSelector.() -> T) =
-            this@DomTreeElement.selection(this@DomTreeElement.toRawCssSelector(), init)
+        return applyNonTrivialSelector(rawCssSelector)
+    }
 
     override fun toString() = element.toString()
 }

--- a/src/main/kotlin/it/skrape/selects/html5/CustomTagSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/CustomTagSelectors.kt
@@ -1,8 +1,7 @@
 package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DocElement
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a html5 custom tags css query selector.
@@ -14,11 +13,8 @@ import it.skrape.selects.DocElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
         selection("$tag$cssSelector", init)
 
 fun <T> CssSelector.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector $tag$cssSelector", init)
-
-fun <T> DocElement.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("$tag$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/CustomTagSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/CustomTagSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a html5 custom tags css query selector.
@@ -13,8 +13,5 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
         selection("$tag$cssSelector", init)
-
-fun <T> CssSelector.customTag(tag: String, cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector $tag$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/DemarcatingEditsSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/DemarcatingEditsSelectors.kt
@@ -1,8 +1,7 @@
 package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DocElement
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <del>-tags css query selector.
@@ -14,14 +13,11 @@ import it.skrape.selects.DocElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.del(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.del(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("del$cssSelector", init)
 
 fun <T> CssSelector.del(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector del$cssSelector", init)
-
-fun <T> DocElement.del(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("del$cssSelector", init)
 
 /**
  * Will define a <ins>-tags css query selector.
@@ -33,11 +29,8 @@ fun <T> DocElement.del(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.ins(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.ins(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ins$cssSelector", init)
 
 fun <T> CssSelector.ins(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector ins$cssSelector", init)
-
-fun <T> DocElement.ins(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("ins$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/DemarcatingEditsSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/DemarcatingEditsSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <del>-tags css query selector.
@@ -13,11 +13,8 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.del(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.del(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("del$cssSelector", init)
-
-fun <T> CssSelector.del(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector del$cssSelector", init)
 
 /**
  * Will define a <ins>-tags css query selector.
@@ -29,8 +26,5 @@ fun <T> CssSelector.del(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.ins(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.ins(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ins$cssSelector", init)
-
-fun <T> CssSelector.ins(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector ins$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/EmbeddedContentSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/EmbeddedContentSelectors.kt
@@ -1,8 +1,7 @@
 package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DocElement
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <applet>-tags css query selector.
@@ -14,14 +13,11 @@ import it.skrape.selects.DocElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.applet(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.applet(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("applet$cssSelector", init)
 
 fun <T> CssSelector.applet(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector applet$cssSelector", init)
-
-fun <T> DocElement.applet(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("applet$cssSelector", init)
 
 /**
  * Will define a <embed>-tags css query selector.
@@ -33,14 +29,11 @@ fun <T> DocElement.applet(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.embed(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.embed(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("embed$cssSelector", init)
 
 fun <T> CssSelector.embed(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector embed$cssSelector", init)
-
-fun <T> DocElement.embed(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("embed$cssSelector", init)
 
 /**
  * Will define a <iframe>-tags css query selector.
@@ -52,14 +45,11 @@ fun <T> DocElement.embed(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("iframe$cssSelector", init)
 
 fun <T> CssSelector.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector iframe$cssSelector", init)
-
-fun <T> DocElement.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("iframe$cssSelector", init)
 
 /**
  * Will define a <noembed>-tags css query selector.
@@ -71,14 +61,11 @@ fun <T> DocElement.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("noembed$cssSelector", init)
 
 fun <T> CssSelector.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector noembed$cssSelector", init)
-
-fun <T> DocElement.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("noembed$cssSelector", init)
 
 /**
  * Will define a <object>-tags css query selector.
@@ -90,14 +77,11 @@ fun <T> DocElement.noembed(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("object$cssSelector", init)
 
 fun <T> CssSelector.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector object$cssSelector", init)
-
-fun <T> DocElement.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("object$cssSelector", init)
 
 /**
  * Will define a <param>-tags css query selector.
@@ -109,14 +93,11 @@ fun <T> DocElement.`object`(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.param(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.param(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("param$cssSelector", init)
 
 fun <T> CssSelector.param(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector param$cssSelector", init)
-
-fun <T> DocElement.param(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("param$cssSelector", init)
 
 /**
  * Will define a <picture>-tags css query selector.
@@ -128,14 +109,11 @@ fun <T> DocElement.param(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.picture(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.picture(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("picture$cssSelector", init)
 
 fun <T> CssSelector.picture(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector picture$cssSelector", init)
-
-fun <T> DocElement.picture(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("picture$cssSelector", init)
 
 /**
  * Will define a <source>-tags css query selector.
@@ -147,11 +125,8 @@ fun <T> DocElement.picture(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.source(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.source(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("source$cssSelector", init)
 
 fun <T> CssSelector.source(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector source$cssSelector", init)
-
-fun <T> DocElement.source(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("source$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/EmbeddedContentSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/EmbeddedContentSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <applet>-tags css query selector.
@@ -13,11 +13,8 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.applet(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.applet(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("applet$cssSelector", init)
-
-fun <T> CssSelector.applet(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector applet$cssSelector", init)
 
 /**
  * Will define a <embed>-tags css query selector.
@@ -29,11 +26,8 @@ fun <T> CssSelector.applet(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.embed(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.embed(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("embed$cssSelector", init)
-
-fun <T> CssSelector.embed(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector embed$cssSelector", init)
 
 /**
  * Will define a <iframe>-tags css query selector.
@@ -45,11 +39,8 @@ fun <T> CssSelector.embed(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("iframe$cssSelector", init)
-
-fun <T> CssSelector.iframe(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector iframe$cssSelector", init)
 
 /**
  * Will define a <noembed>-tags css query selector.
@@ -61,11 +52,8 @@ fun <T> CssSelector.iframe(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("noembed$cssSelector", init)
-
-fun <T> CssSelector.noembed(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector noembed$cssSelector", init)
 
 /**
  * Will define a <object>-tags css query selector.
@@ -77,11 +65,8 @@ fun <T> CssSelector.noembed(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("object$cssSelector", init)
-
-fun <T> CssSelector.`object`(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector object$cssSelector", init)
 
 /**
  * Will define a <param>-tags css query selector.
@@ -93,11 +78,8 @@ fun <T> CssSelector.`object`(cssSelector: String = "", init: CssSelector.() -> T
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.param(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.param(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("param$cssSelector", init)
-
-fun <T> CssSelector.param(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector param$cssSelector", init)
 
 /**
  * Will define a <picture>-tags css query selector.
@@ -109,11 +91,8 @@ fun <T> CssSelector.param(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.picture(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.picture(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("picture$cssSelector", init)
-
-fun <T> CssSelector.picture(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector picture$cssSelector", init)
 
 /**
  * Will define a <source>-tags css query selector.
@@ -125,8 +104,5 @@ fun <T> CssSelector.picture(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.source(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.source(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("source$cssSelector", init)
-
-fun <T> CssSelector.source(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector source$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/FormSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/FormSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <button>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.button(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.button(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("button$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.button(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.datalist(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.datalist(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("datalist$cssSelector", init)
 
 /**
@@ -39,7 +39,7 @@ fun <T> Doc.datalist(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.fieldset(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.fieldset(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("fieldset$cssSelector", init)
 
 /**
@@ -52,7 +52,7 @@ fun <T> Doc.fieldset(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.form(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.form(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("form$cssSelector", init)
 
 /**
@@ -65,7 +65,7 @@ fun <T> Doc.form(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.input(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.input(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("input$cssSelector", init)
 
 /**
@@ -78,7 +78,7 @@ fun <T> Doc.input(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.label(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.label(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("label$cssSelector", init)
 
 /**
@@ -91,7 +91,7 @@ fun <T> Doc.label(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.legend(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.legend(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("legend$cssSelector", init)
 
 /**
@@ -104,7 +104,7 @@ fun <T> Doc.legend(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.meter(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.meter(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("meter$cssSelector", init)
 
 /**
@@ -117,7 +117,7 @@ fun <T> Doc.meter(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.optgroup(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.optgroup(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("optgroup$cssSelector", init)
 
 /**
@@ -130,7 +130,7 @@ fun <T> Doc.optgroup(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.option(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.option(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("option$cssSelector", init)
 
 /**
@@ -143,7 +143,7 @@ fun <T> Doc.option(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.output(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.output(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("output$cssSelector", init)
 
 /**
@@ -156,7 +156,7 @@ fun <T> Doc.output(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.progress(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.progress(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("progress$cssSelector", init)
 
 /**
@@ -169,7 +169,7 @@ fun <T> Doc.progress(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.select(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.select(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("isPresent$cssSelector", init)
 
 /**
@@ -182,5 +182,5 @@ fun <T> Doc.select(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.textarea(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.textarea(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("textarea$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/InteractiveSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/InteractiveSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <details>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.details(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.details(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("details$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.details(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dialog(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dialog(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dialog$cssSelector", init)
 
 /**
@@ -39,7 +39,7 @@ fun <T> Doc.dialog(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.menu(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.menu(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("menu$cssSelector", init)
 
 /**
@@ -52,7 +52,7 @@ fun <T> Doc.menu(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.menuitem(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.menuitem(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("menuitem$cssSelector", init)
 
 /**
@@ -65,5 +65,5 @@ fun <T> Doc.menuitem(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.summary(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.summary(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("summary$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/MainRootSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/MainRootSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <html>-tags css query selector.
@@ -13,5 +13,5 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.html(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.html(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("html$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/MediaSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/MediaSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <area>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.area(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.area(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("area$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.area(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.audio(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.audio(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("audio$cssSelector", init)
 
 /**
@@ -39,7 +39,7 @@ fun <T> Doc.audio(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.img(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.img(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("img$cssSelector", init)
 
 /**
@@ -52,7 +52,7 @@ fun <T> Doc.img(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.map(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.map(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("map$cssSelector", init)
 
 /**
@@ -65,7 +65,7 @@ fun <T> Doc.map(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.track(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.track(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("track$cssSelector", init)
 
 /**
@@ -78,5 +78,5 @@ fun <T> Doc.track(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.video(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.video(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("video$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/MetadataSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/MetadataSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <base>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.base(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.base(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("base$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.base(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.head(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.head(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("head$cssSelector", init)
 
 /**
@@ -39,7 +39,7 @@ fun <T> Doc.head(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.link(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.link(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("link$cssSelector", init)
 
 /**
@@ -52,7 +52,7 @@ fun <T> Doc.link(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.meta(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.meta(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("meta$cssSelector", init)
 
 /**
@@ -65,7 +65,7 @@ fun <T> Doc.meta(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.style(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.style(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("style$cssSelector", init)
 
 /**
@@ -78,5 +78,5 @@ fun <T> Doc.style(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.title(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.title(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("title$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/ScriptingSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/ScriptingSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <script>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.script(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.script(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("script$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.script(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.canvas(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.canvas(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("canvas$cssSelector", init)
 
 /**
@@ -39,5 +39,5 @@ fun <T> Doc.canvas(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.noscript(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.noscript(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("noscript$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/SectioningSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/SectioningSelectors.kt
@@ -4,7 +4,7 @@ package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
 import it.skrape.selects.Doc
-import it.skrape.selects.DocElement
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <body>-tags css query selector.
@@ -29,14 +29,11 @@ fun <T> Doc.body(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.div(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.div(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("div$cssSelector", init)
 
 fun <T> CssSelector.div(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector div$cssSelector", init)
-
-fun <T> DocElement.div(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("div$cssSelector", init)
 
 /**
  * Will define a <section>-tags css query selector.
@@ -48,14 +45,11 @@ fun <T> DocElement.div(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.section(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.section(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("section$cssSelector", init)
 
 fun <T> CssSelector.section(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector section$cssSelector", init)
-
-fun <T> DocElement.section(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("section$cssSelector", init)
 
 /**
  * Will define a <nav>-tags css query selector.
@@ -67,14 +61,11 @@ fun <T> DocElement.section(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.nav(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.nav(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("nav$cssSelector", init)
 
 fun <T> CssSelector.nav(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector nav$cssSelector", init)
-
-fun <T> DocElement.nav(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("nav$cssSelector", init)
 
 /**
  * Will define a <article>-tags css query selector.
@@ -86,14 +77,11 @@ fun <T> DocElement.nav(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.article(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.article(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("article$cssSelector", init)
 
 fun <T> CssSelector.article(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector article$cssSelector", init)
-
-fun <T> DocElement.article(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("article$cssSelector", init)
 
 /**
  * Will define a <aside>-tags css query selector.
@@ -105,14 +93,11 @@ fun <T> DocElement.article(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.aside(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.aside(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("aside$cssSelector", init)
 
 fun <T> CssSelector.aside(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector aside$cssSelector", init)
-
-fun <T> DocElement.aside(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("aside$cssSelector", init)
 
 /**
  * Will define a <h1>-tags css query selector.
@@ -124,14 +109,11 @@ fun <T> DocElement.aside(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h1(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h1(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h1$cssSelector", init)
 
 fun <T> CssSelector.h1(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h1$cssSelector", init)
-
-fun <T> DocElement.h1(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h1$cssSelector", init)
 
 /**
  * Will define a <h2>-tags css query selector.
@@ -143,14 +125,11 @@ fun <T> DocElement.h1(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h2(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h2(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h2$cssSelector", init)
 
 fun <T> CssSelector.h2(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h2$cssSelector", init)
-
-fun <T> DocElement.h2(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h2$cssSelector", init)
 
 /**
  * Will define a <h3>-tags css query selector.
@@ -162,14 +141,11 @@ fun <T> DocElement.h2(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h3(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h3(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h3$cssSelector", init)
 
 fun <T> CssSelector.h3(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h3$cssSelector", init)
-
-fun <T> DocElement.h3(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h3$cssSelector", init)
 
 /**
  * Will define a <h4>-tags css query selector.
@@ -181,14 +157,11 @@ fun <T> DocElement.h3(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h4(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h4(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h4$cssSelector", init)
 
 fun <T> CssSelector.h4(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h4$cssSelector", init)
-
-fun <T> DocElement.h4(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h4$cssSelector", init)
 
 /**
  * Will define a <h5>-tags css query selector.
@@ -200,14 +173,11 @@ fun <T> DocElement.h4(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h5(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h5(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h5$cssSelector", init)
 
 fun <T> CssSelector.h5(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h5$cssSelector", init)
-
-fun <T> DocElement.h5(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h5$cssSelector", init)
 
 /**
  * Will define a <h6>-tags css query selector.
@@ -219,14 +189,11 @@ fun <T> DocElement.h5(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.h6(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.h6(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h6$cssSelector", init)
 
 fun <T> CssSelector.h6(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector h6$cssSelector", init)
-
-fun <T> DocElement.h6(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("h6$cssSelector", init)
 
 /**
  * Will define a <header>-tags css query selector.
@@ -238,14 +205,11 @@ fun <T> DocElement.h6(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.header(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.header(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("header$cssSelector", init)
 
 fun <T> CssSelector.header(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector header$cssSelector", init)
-
-fun <T> DocElement.header(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("header$cssSelector", init)
 
 /**
  * Will define a <footer>-tags css query selector.
@@ -257,14 +221,11 @@ fun <T> DocElement.header(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.footer(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.footer(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("footer$cssSelector", init)
 
 fun <T> CssSelector.footer(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector footer$cssSelector", init)
-
-fun <T> DocElement.footer(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("footer$cssSelector", init)
 
 /**
  * Will define a <address>-tags css query selector.
@@ -276,14 +237,11 @@ fun <T> DocElement.footer(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.address(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.address(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("address$cssSelector", init)
 
 fun <T> CssSelector.address(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector address$cssSelector", init)
-
-fun <T> DocElement.address(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("address$cssSelector", init)
 
 /**
  * Will define a <main>-tags css query selector.
@@ -295,11 +253,8 @@ fun <T> DocElement.address(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.main(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.main(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("main$cssSelector", init)
 
 fun <T> CssSelector.main(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector main$cssSelector", init)
-
-fun <T> DocElement.main(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("main$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/SectioningSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/SectioningSelectors.kt
@@ -2,9 +2,8 @@
 
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <body>-tags css query selector.
@@ -16,7 +15,7 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.body(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.body(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("body$cssSelector", init)
 
 /**
@@ -29,11 +28,8 @@ fun <T> Doc.body(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.div(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.div(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("div$cssSelector", init)
-
-fun <T> CssSelector.div(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector div$cssSelector", init)
 
 /**
  * Will define a <section>-tags css query selector.
@@ -45,11 +41,8 @@ fun <T> CssSelector.div(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.section(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.section(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("section$cssSelector", init)
-
-fun <T> CssSelector.section(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector section$cssSelector", init)
 
 /**
  * Will define a <nav>-tags css query selector.
@@ -61,11 +54,8 @@ fun <T> CssSelector.section(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.nav(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.nav(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("nav$cssSelector", init)
-
-fun <T> CssSelector.nav(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector nav$cssSelector", init)
 
 /**
  * Will define a <article>-tags css query selector.
@@ -77,11 +67,8 @@ fun <T> CssSelector.nav(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.article(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.article(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("article$cssSelector", init)
-
-fun <T> CssSelector.article(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector article$cssSelector", init)
 
 /**
  * Will define a <aside>-tags css query selector.
@@ -93,11 +80,8 @@ fun <T> CssSelector.article(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.aside(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.aside(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("aside$cssSelector", init)
-
-fun <T> CssSelector.aside(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector aside$cssSelector", init)
 
 /**
  * Will define a <h1>-tags css query selector.
@@ -109,11 +93,8 @@ fun <T> CssSelector.aside(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h1(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h1(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h1$cssSelector", init)
-
-fun <T> CssSelector.h1(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h1$cssSelector", init)
 
 /**
  * Will define a <h2>-tags css query selector.
@@ -125,11 +106,8 @@ fun <T> CssSelector.h1(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h2(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h2(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h2$cssSelector", init)
-
-fun <T> CssSelector.h2(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h2$cssSelector", init)
 
 /**
  * Will define a <h3>-tags css query selector.
@@ -141,11 +119,8 @@ fun <T> CssSelector.h2(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h3(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h3(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h3$cssSelector", init)
-
-fun <T> CssSelector.h3(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h3$cssSelector", init)
 
 /**
  * Will define a <h4>-tags css query selector.
@@ -157,11 +132,8 @@ fun <T> CssSelector.h3(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h4(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h4(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h4$cssSelector", init)
-
-fun <T> CssSelector.h4(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h4$cssSelector", init)
 
 /**
  * Will define a <h5>-tags css query selector.
@@ -173,11 +145,8 @@ fun <T> CssSelector.h4(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h5(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h5(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h5$cssSelector", init)
-
-fun <T> CssSelector.h5(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h5$cssSelector", init)
 
 /**
  * Will define a <h6>-tags css query selector.
@@ -189,11 +158,8 @@ fun <T> CssSelector.h5(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.h6(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.h6(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("h6$cssSelector", init)
-
-fun <T> CssSelector.h6(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector h6$cssSelector", init)
 
 /**
  * Will define a <header>-tags css query selector.
@@ -205,11 +171,8 @@ fun <T> CssSelector.h6(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.header(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.header(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("header$cssSelector", init)
-
-fun <T> CssSelector.header(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector header$cssSelector", init)
 
 /**
  * Will define a <footer>-tags css query selector.
@@ -221,11 +184,8 @@ fun <T> CssSelector.header(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.footer(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.footer(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("footer$cssSelector", init)
-
-fun <T> CssSelector.footer(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector footer$cssSelector", init)
 
 /**
  * Will define a <address>-tags css query selector.
@@ -237,11 +197,8 @@ fun <T> CssSelector.footer(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.address(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.address(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("address$cssSelector", init)
-
-fun <T> CssSelector.address(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector address$cssSelector", init)
 
 /**
  * Will define a <main>-tags css query selector.
@@ -253,8 +210,5 @@ fun <T> CssSelector.address(cssSelector: String = "", init: CssSelector.() -> T)
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.main(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.main(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("main$cssSelector", init)
-
-fun <T> CssSelector.main(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector main$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/TableSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TableSelectors.kt
@@ -1,8 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <caption>-tags css query selector.
@@ -14,7 +13,7 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.caption(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.caption(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("caption$cssSelector", init)
 
 /**
@@ -27,11 +26,8 @@ fun <T> Doc.caption(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.col(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.col(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("col$cssSelector", init)
-
-fun <T> CssSelector.col(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector col$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <colgroup>-tags css query selector.
@@ -43,11 +39,8 @@ fun <T> CssSelector.col(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("colgroup$cssSelector", init)
-
-fun <T> CssSelector.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector colgroup$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <table>-tags css query selector.
@@ -59,11 +52,8 @@ fun <T> CssSelector.colgroup(cssSelector: String = "", init: CssSelector.() -> T
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.table(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.table(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("table$cssSelector", init)
-
-fun <T> CssSelector.table(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector table$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <tbody>-tags css query selector.
@@ -75,11 +65,8 @@ fun <T> CssSelector.table(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tbody$cssSelector", init)
-
-fun <T> CssSelector.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector tbody$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <td>-tags css query selector.
@@ -91,11 +78,8 @@ fun <T> CssSelector.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.td(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.td(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("td$cssSelector", init)
-
-fun <T> CssSelector.td(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector td$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <tfoot>-tags css query selector.
@@ -107,11 +91,8 @@ fun <T> CssSelector.td(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tfoot$cssSelector", init)
-
-fun <T> CssSelector.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector tfoot$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <th>-tags css query selector.
@@ -123,11 +104,8 @@ fun <T> CssSelector.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.th(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.th(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("th$cssSelector", init)
-
-fun <T> CssSelector.th(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector th$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <thead>-tags css query selector.
@@ -139,11 +117,8 @@ fun <T> CssSelector.th(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.thead(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.thead(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("thead$cssSelector", init)
-
-fun <T> CssSelector.thead(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector thead$cssSelector", doc = this.doc).init()
 
 /**
  * Will define a <tr>-tags css query selector.
@@ -155,8 +130,5 @@ fun <T> CssSelector.thead(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.tr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.tr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tr$cssSelector", init)
-
-fun <T> CssSelector.tr(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector tr$cssSelector", doc = this.doc).init()

--- a/src/main/kotlin/it/skrape/selects/html5/TableSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TableSelectors.kt
@@ -2,6 +2,7 @@ package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
 import it.skrape.selects.Doc
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <caption>-tags css query selector.
@@ -26,7 +27,7 @@ fun <T> Doc.caption(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.col(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.col(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("col$cssSelector", init)
 
 fun <T> CssSelector.col(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -42,7 +43,7 @@ fun <T> CssSelector.col(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("colgroup$cssSelector", init)
 
 fun <T> CssSelector.colgroup(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -58,7 +59,7 @@ fun <T> CssSelector.colgroup(cssSelector: String = "", init: CssSelector.() -> T
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.table(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.table(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("table$cssSelector", init)
 
 fun <T> CssSelector.table(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -74,7 +75,7 @@ fun <T> CssSelector.table(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tbody$cssSelector", init)
 
 fun <T> CssSelector.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -90,7 +91,7 @@ fun <T> CssSelector.tbody(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.td(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.td(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("td$cssSelector", init)
 
 fun <T> CssSelector.td(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -106,7 +107,7 @@ fun <T> CssSelector.td(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tfoot$cssSelector", init)
 
 fun <T> CssSelector.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -122,7 +123,7 @@ fun <T> CssSelector.tfoot(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.th(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.th(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("th$cssSelector", init)
 
 fun <T> CssSelector.th(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -138,7 +139,7 @@ fun <T> CssSelector.th(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.thead(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.thead(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("thead$cssSelector", init)
 
 fun <T> CssSelector.thead(cssSelector: String = "", init: CssSelector.() -> T) =
@@ -154,7 +155,7 @@ fun <T> CssSelector.thead(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.tr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.tr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tr$cssSelector", init)
 
 fun <T> CssSelector.tr(cssSelector: String = "", init: CssSelector.() -> T) =

--- a/src/main/kotlin/it/skrape/selects/html5/TextContentSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TextContentSelectors.kt
@@ -1,8 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <blockquote>-tags css query selector.
@@ -14,7 +13,7 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.blockquote(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.blockquote(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("blockquote$cssSelector", init)
 
 /**
@@ -27,7 +26,7 @@ fun <T> Doc.blockquote(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dd(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dd(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dd$cssSelector", init)
 
 /**
@@ -40,7 +39,7 @@ fun <T> Doc.dd(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dir(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dir(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dir$cssSelector", init)
 
 /**
@@ -53,7 +52,7 @@ fun <T> Doc.dir(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dl(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dl(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dl$cssSelector", init)
 
 /**
@@ -66,7 +65,7 @@ fun <T> Doc.dl(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dt(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dt(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dt$cssSelector", init)
 
 /**
@@ -79,7 +78,7 @@ fun <T> Doc.dt(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.figcaption(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.figcaption(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("figcaption$cssSelector", init)
 
 /**
@@ -92,7 +91,7 @@ fun <T> Doc.figcaption(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.figure(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.figure(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("figure$cssSelector", init)
 
 /**
@@ -105,7 +104,7 @@ fun <T> Doc.figure(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.hr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.hr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("hr$cssSelector", init)
 
 /**
@@ -118,7 +117,7 @@ fun <T> Doc.hr(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.li(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.li(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("li$cssSelector", init)
 
 /**
@@ -131,7 +130,7 @@ fun <T> Doc.li(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.ol(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.ol(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ol$cssSelector", init)
 
 /**
@@ -144,7 +143,7 @@ fun <T> Doc.ol(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.ul(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.ul(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ul$cssSelector", init)
 
 /**
@@ -157,11 +156,8 @@ fun <T> Doc.ul(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.p(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.p(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("p$cssSelector", init)
-
-fun <T> CssSelector.p(cssSelector: String = "", init: CssSelector.() -> T) =
-        CssSelector("$toCssSelector p$cssSelector").init()
 
 /**
  * Will define a <pre>-tags css query selector.
@@ -173,5 +169,5 @@ fun <T> CssSelector.p(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.pre(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.pre(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("pre$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/TextContentSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TextContentSelectors.kt
@@ -2,6 +2,7 @@ package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
 import it.skrape.selects.Doc
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <blockquote>-tags css query selector.
@@ -156,7 +157,7 @@ fun <T> Doc.ul(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.p(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.p(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("p$cssSelector", init)
 
 fun <T> CssSelector.p(cssSelector: String = "", init: CssSelector.() -> T) =

--- a/src/main/kotlin/it/skrape/selects/html5/TextSemanticsSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TextSemanticsSelectors.kt
@@ -2,8 +2,8 @@
 
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <a>-tags css query selector.
@@ -15,11 +15,8 @@ import it.skrape.selects.DomTreeElement
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.a(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.a(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("a$cssSelector", init)
-
-fun <T> CssSelector.a(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector a$cssSelector", init)
 
 /**
  * Will define a <abbr>-tags css query selector.
@@ -31,11 +28,8 @@ fun <T> CssSelector.a(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("abbr$cssSelector", init)
-
-fun <T> CssSelector.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector abbr$cssSelector", init)
 
 /**
  * Will define a <b>-tags css query selector.
@@ -47,11 +41,8 @@ fun <T> CssSelector.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.b(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.b(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("b$cssSelector", init)
-
-fun <T> CssSelector.b(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector b$cssSelector", init)
 
 /**
  * Will define a <bdi>-tags css query selector.
@@ -63,11 +54,8 @@ fun <T> CssSelector.b(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("bdi$cssSelector", init)
-
-fun <T> CssSelector.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector bdi$cssSelector", init)
 
 /**
  * Will define a <bdo>-tags css query selector.
@@ -79,11 +67,8 @@ fun <T> CssSelector.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("bdo$cssSelector", init)
-
-fun <T> CssSelector.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector bdo$cssSelector", init)
 
 /**
  * Will define a <br>-tags css query selector.
@@ -95,11 +80,8 @@ fun <T> CssSelector.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.br(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.br(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("br$cssSelector", init)
-
-fun <T> CssSelector.br(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector br$cssSelector", init)
 
 /**
  * Will define a <cite>-tags css query selector.
@@ -111,11 +93,8 @@ fun <T> CssSelector.br(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.cite(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.cite(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("cite$cssSelector", init)
-
-fun <T> CssSelector.cite(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector cite$cssSelector", init)
 
 /**
  * Will define a <code>-tags css query selector.
@@ -127,11 +106,8 @@ fun <T> CssSelector.cite(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.code(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.code(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("code$cssSelector", init)
-
-fun <T> CssSelector.code(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector code$cssSelector", init)
 
 /**
  * Will define a <data>-tags css query selector.
@@ -143,11 +119,8 @@ fun <T> CssSelector.code(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.data(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.data(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("data$cssSelector", init)
-
-fun <T> CssSelector.data(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector data$cssSelector", init)
 
 /**
  * Will define a <dfn>-tags css query selector.
@@ -159,11 +132,8 @@ fun <T> CssSelector.data(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dfn$cssSelector", init)
-
-fun <T> CssSelector.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector dfn$cssSelector", init)
 
 /**
  * Will define a <em>-tags css query selector.
@@ -175,11 +145,8 @@ fun <T> CssSelector.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.em(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.em(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("em$cssSelector", init)
-
-fun <T> CssSelector.em(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector em$cssSelector", init)
 
 /**
  * Will define a <i>-tags css query selector.
@@ -191,11 +158,8 @@ fun <T> CssSelector.em(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.i(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.i(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("i$cssSelector", init)
-
-fun <T> CssSelector.i(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector i$cssSelector", init)
 
 /**
  * Will define a <kbd>-tags css query selector.
@@ -207,11 +171,8 @@ fun <T> CssSelector.i(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("kbd$cssSelector", init)
-
-fun <T> CssSelector.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector kbd$cssSelector", init)
 
 /**
  * Will define a <mark>-tags css query selector.
@@ -223,11 +184,8 @@ fun <T> CssSelector.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.mark(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.mark(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("mark$cssSelector", init)
-
-fun <T> CssSelector.mark(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector mark$cssSelector", init)
 
 /**
  * Will define a <q>-tags css query selector.
@@ -239,11 +197,8 @@ fun <T> CssSelector.mark(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.q(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.q(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("q$cssSelector", init)
-
-fun <T> CssSelector.q(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector q$cssSelector", init)
 
 /**
  * Will define a <rb>-tags css query selector.
@@ -255,11 +210,8 @@ fun <T> CssSelector.q(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.rb(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.rb(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("rb$cssSelector", init)
-
-fun <T> CssSelector.rb(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector rb$cssSelector", init)
 
 /**
  * Will define a <rtc>-tags css query selector.
@@ -271,11 +223,8 @@ fun <T> CssSelector.rb(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("rtc$cssSelector", init)
-
-fun <T> CssSelector.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector rtc$cssSelector", init)
 
 /**
  * Will define a <ruby>-tags css query selector.
@@ -287,11 +236,8 @@ fun <T> CssSelector.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ruby$cssSelector", init)
-
-fun <T> CssSelector.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector ruby$cssSelector", init)
 
 /**
  * Will define a <s>-tags css query selector.
@@ -303,11 +249,8 @@ fun <T> CssSelector.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.s(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.s(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("s$cssSelector", init)
-
-fun <T> CssSelector.s(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector s$cssSelector", init)
 
 /**
  * Will define a <samp>-tags css query selector.
@@ -319,11 +262,8 @@ fun <T> CssSelector.s(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.samp(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.samp(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("samp$cssSelector", init)
-
-fun <T> CssSelector.samp(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector samp$cssSelector", init)
 
 /**
  * Will define a <small>-tags css query selector.
@@ -335,11 +275,8 @@ fun <T> CssSelector.samp(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.small(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.small(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("small$cssSelector", init)
-
-fun <T> CssSelector.small(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector small$cssSelector", init)
 
 /**
  * Will define a <span>-tags css query selector.
@@ -351,11 +288,8 @@ fun <T> CssSelector.small(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.span(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.span(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("span$cssSelector", init)
-
-fun <T> CssSelector.span(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector span$cssSelector", init)
 
 /**
  * Will define a <strong>-tags css query selector.
@@ -367,11 +301,8 @@ fun <T> CssSelector.span(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.strong(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.strong(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("strong$cssSelector", init)
-
-fun <T> CssSelector.strong(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector strong$cssSelector", init)
 
 /**
  * Will define a <sub>-tags css query selector.
@@ -383,11 +314,8 @@ fun <T> CssSelector.strong(cssSelector: String = "", init: CssSelector.() -> T) 
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.sub(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.sub(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("sub$cssSelector", init)
-
-fun <T> CssSelector.sub(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector sub$cssSelector", init)
 
 /**
  * Will define a <sup>-tags css query selector.
@@ -399,11 +327,8 @@ fun <T> CssSelector.sub(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.sup(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.sup(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("sup$cssSelector", init)
-
-fun <T> CssSelector.sup(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector sup$cssSelector", init)
 
 /**
  * Will define a <time>-tags css query selector.
@@ -415,11 +340,8 @@ fun <T> CssSelector.sup(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.time(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.time(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("time$cssSelector", init)
-
-fun <T> CssSelector.time(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector time$cssSelector", init)
 
 /**
  * Will define a <tt>-tags css query selector.
@@ -431,11 +353,8 @@ fun <T> CssSelector.time(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.tt(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.tt(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tt$cssSelector", init)
-
-fun <T> CssSelector.tt(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector tt$cssSelector", init)
 
 /**
  * Will define a <u>-tags css query selector.
@@ -447,11 +366,8 @@ fun <T> CssSelector.tt(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.u(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.u(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("u$cssSelector", init)
-
-fun <T> CssSelector.u(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector u$cssSelector", init)
 
 /**
  * Will define a <var>-tags css query selector.
@@ -463,11 +379,8 @@ fun <T> CssSelector.u(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("var$cssSelector", init)
-
-fun <T> CssSelector.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector var$cssSelector", init)
 
 /**
  * Will define a <wbr>-tags css query selector.
@@ -479,8 +392,5 @@ fun <T> CssSelector.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> DomTreeElement.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("wbr$cssSelector", init)
-
-fun <T> CssSelector.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
-        doc.selection("$toCssSelector wbr$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/TextSemanticsSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/TextSemanticsSelectors.kt
@@ -3,8 +3,7 @@
 package it.skrape.selects.html5
 
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
-import it.skrape.selects.DocElement
+import it.skrape.selects.DomTreeElement
 
 /**
  * Will define a <a>-tags css query selector.
@@ -16,14 +15,11 @@ import it.skrape.selects.DocElement
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.a(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.a(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("a$cssSelector", init)
 
 fun <T> CssSelector.a(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector a$cssSelector", init)
-
-fun <T> DocElement.a(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("a$cssSelector", init)
 
 /**
  * Will define a <abbr>-tags css query selector.
@@ -35,14 +31,11 @@ fun <T> DocElement.a(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("abbr$cssSelector", init)
 
 fun <T> CssSelector.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector abbr$cssSelector", init)
-
-fun <T> DocElement.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("abbr$cssSelector", init)
 
 /**
  * Will define a <b>-tags css query selector.
@@ -54,14 +47,11 @@ fun <T> DocElement.abbr(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.b(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.b(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("b$cssSelector", init)
 
 fun <T> CssSelector.b(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector b$cssSelector", init)
-
-fun <T> DocElement.b(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("b$cssSelector", init)
 
 /**
  * Will define a <bdi>-tags css query selector.
@@ -73,14 +63,11 @@ fun <T> DocElement.b(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("bdi$cssSelector", init)
 
 fun <T> CssSelector.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector bdi$cssSelector", init)
-
-fun <T> DocElement.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("bdi$cssSelector", init)
 
 /**
  * Will define a <bdo>-tags css query selector.
@@ -92,14 +79,11 @@ fun <T> DocElement.bdi(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("bdo$cssSelector", init)
 
 fun <T> CssSelector.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector bdo$cssSelector", init)
-
-fun <T> DocElement.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("bdo$cssSelector", init)
 
 /**
  * Will define a <br>-tags css query selector.
@@ -111,14 +95,11 @@ fun <T> DocElement.bdo(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.br(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.br(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("br$cssSelector", init)
 
 fun <T> CssSelector.br(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector br$cssSelector", init)
-
-fun <T> DocElement.br(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("br$cssSelector", init)
 
 /**
  * Will define a <cite>-tags css query selector.
@@ -130,14 +111,11 @@ fun <T> DocElement.br(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.cite(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.cite(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("cite$cssSelector", init)
 
 fun <T> CssSelector.cite(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector cite$cssSelector", init)
-
-fun <T> DocElement.cite(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("cite$cssSelector", init)
 
 /**
  * Will define a <code>-tags css query selector.
@@ -149,14 +127,11 @@ fun <T> DocElement.cite(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.code(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.code(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("code$cssSelector", init)
 
 fun <T> CssSelector.code(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector code$cssSelector", init)
-
-fun <T> DocElement.code(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("code$cssSelector", init)
 
 /**
  * Will define a <data>-tags css query selector.
@@ -168,14 +143,11 @@ fun <T> DocElement.code(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.data(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.data(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("data$cssSelector", init)
 
 fun <T> CssSelector.data(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector data$cssSelector", init)
-
-fun <T> DocElement.data(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("data$cssSelector", init)
 
 /**
  * Will define a <dfn>-tags css query selector.
@@ -187,14 +159,11 @@ fun <T> DocElement.data(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("dfn$cssSelector", init)
 
 fun <T> CssSelector.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector dfn$cssSelector", init)
-
-fun <T> DocElement.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("dfn$cssSelector", init)
 
 /**
  * Will define a <em>-tags css query selector.
@@ -206,14 +175,11 @@ fun <T> DocElement.dfn(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.em(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.em(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("em$cssSelector", init)
 
 fun <T> CssSelector.em(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector em$cssSelector", init)
-
-fun <T> DocElement.em(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("em$cssSelector", init)
 
 /**
  * Will define a <i>-tags css query selector.
@@ -225,14 +191,11 @@ fun <T> DocElement.em(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.i(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.i(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("i$cssSelector", init)
 
 fun <T> CssSelector.i(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector i$cssSelector", init)
-
-fun <T> DocElement.i(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("i$cssSelector", init)
 
 /**
  * Will define a <kbd>-tags css query selector.
@@ -244,14 +207,11 @@ fun <T> DocElement.i(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("kbd$cssSelector", init)
 
 fun <T> CssSelector.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector kbd$cssSelector", init)
-
-fun <T> DocElement.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("kbd$cssSelector", init)
 
 /**
  * Will define a <mark>-tags css query selector.
@@ -263,14 +223,11 @@ fun <T> DocElement.kbd(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.mark(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.mark(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("mark$cssSelector", init)
 
 fun <T> CssSelector.mark(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector mark$cssSelector", init)
-
-fun <T> DocElement.mark(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("mark$cssSelector", init)
 
 /**
  * Will define a <q>-tags css query selector.
@@ -282,14 +239,11 @@ fun <T> DocElement.mark(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.q(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.q(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("q$cssSelector", init)
 
 fun <T> CssSelector.q(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector q$cssSelector", init)
-
-fun <T> DocElement.q(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("q$cssSelector", init)
 
 /**
  * Will define a <rb>-tags css query selector.
@@ -301,14 +255,11 @@ fun <T> DocElement.q(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.rb(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.rb(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("rb$cssSelector", init)
 
 fun <T> CssSelector.rb(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector rb$cssSelector", init)
-
-fun <T> DocElement.rb(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("rb$cssSelector", init)
 
 /**
  * Will define a <rtc>-tags css query selector.
@@ -320,14 +271,11 @@ fun <T> DocElement.rb(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("rtc$cssSelector", init)
 
 fun <T> CssSelector.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector rtc$cssSelector", init)
-
-fun <T> DocElement.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("rtc$cssSelector", init)
 
 /**
  * Will define a <ruby>-tags css query selector.
@@ -339,14 +287,11 @@ fun <T> DocElement.rtc(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("ruby$cssSelector", init)
 
 fun <T> CssSelector.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector ruby$cssSelector", init)
-
-fun <T> DocElement.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("ruby$cssSelector", init)
 
 /**
  * Will define a <s>-tags css query selector.
@@ -358,14 +303,11 @@ fun <T> DocElement.ruby(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.s(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.s(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("s$cssSelector", init)
 
 fun <T> CssSelector.s(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector s$cssSelector", init)
-
-fun <T> DocElement.s(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("s$cssSelector", init)
 
 /**
  * Will define a <samp>-tags css query selector.
@@ -377,14 +319,11 @@ fun <T> DocElement.s(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.samp(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.samp(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("samp$cssSelector", init)
 
 fun <T> CssSelector.samp(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector samp$cssSelector", init)
-
-fun <T> DocElement.samp(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("samp$cssSelector", init)
 
 /**
  * Will define a <small>-tags css query selector.
@@ -396,14 +335,11 @@ fun <T> DocElement.samp(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.small(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.small(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("small$cssSelector", init)
 
 fun <T> CssSelector.small(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector small$cssSelector", init)
-
-fun <T> DocElement.small(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("small$cssSelector", init)
 
 /**
  * Will define a <span>-tags css query selector.
@@ -415,14 +351,11 @@ fun <T> DocElement.small(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.span(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.span(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("span$cssSelector", init)
 
 fun <T> CssSelector.span(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector span$cssSelector", init)
-
-fun <T> DocElement.span(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("span$cssSelector", init)
 
 /**
  * Will define a <strong>-tags css query selector.
@@ -434,14 +367,11 @@ fun <T> DocElement.span(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.strong(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.strong(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("strong$cssSelector", init)
 
 fun <T> CssSelector.strong(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector strong$cssSelector", init)
-
-fun <T> DocElement.strong(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("strong$cssSelector", init)
 
 /**
  * Will define a <sub>-tags css query selector.
@@ -453,14 +383,11 @@ fun <T> DocElement.strong(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.sub(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.sub(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("sub$cssSelector", init)
 
 fun <T> CssSelector.sub(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector sub$cssSelector", init)
-
-fun <T> DocElement.sub(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("sub$cssSelector", init)
 
 /**
  * Will define a <sup>-tags css query selector.
@@ -472,14 +399,11 @@ fun <T> DocElement.sub(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.sup(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.sup(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("sup$cssSelector", init)
 
 fun <T> CssSelector.sup(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector sup$cssSelector", init)
-
-fun <T> DocElement.sup(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("sup$cssSelector", init)
 
 /**
  * Will define a <time>-tags css query selector.
@@ -491,14 +415,11 @@ fun <T> DocElement.sup(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.time(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.time(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("time$cssSelector", init)
 
 fun <T> CssSelector.time(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector time$cssSelector", init)
-
-fun <T> DocElement.time(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("time$cssSelector", init)
 
 /**
  * Will define a <tt>-tags css query selector.
@@ -510,14 +431,11 @@ fun <T> DocElement.time(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.tt(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.tt(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("tt$cssSelector", init)
 
 fun <T> CssSelector.tt(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector tt$cssSelector", init)
-
-fun <T> DocElement.tt(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("tt$cssSelector", init)
 
 /**
  * Will define a <u>-tags css query selector.
@@ -529,14 +447,11 @@ fun <T> DocElement.tt(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.u(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.u(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("u$cssSelector", init)
 
 fun <T> CssSelector.u(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector u$cssSelector", init)
-
-fun <T> DocElement.u(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("u$cssSelector", init)
 
 /**
  * Will define a <var>-tags css query selector.
@@ -548,14 +463,11 @@ fun <T> DocElement.u(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("var$cssSelector", init)
 
 fun <T> CssSelector.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector var$cssSelector", init)
-
-fun <T> DocElement.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("var$cssSelector", init)
 
 /**
  * Will define a <wbr>-tags css query selector.
@@ -567,11 +479,8 @@ fun <T> DocElement.`var`(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> DomTreeElement.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("wbr$cssSelector", init)
 
 fun <T> CssSelector.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
         doc.selection("$toCssSelector wbr$cssSelector", init)
-
-fun <T> DocElement.wbr(cssSelector: String = "", init: CssSelector.() -> T) =
-        toDoc.selection("wbr$cssSelector", init)

--- a/src/main/kotlin/it/skrape/selects/html5/WebComponentsSelectors.kt
+++ b/src/main/kotlin/it/skrape/selects/html5/WebComponentsSelectors.kt
@@ -1,7 +1,7 @@
 package it.skrape.selects.html5
 
+import it.skrape.selects.CssSelectable
 import it.skrape.selects.CssSelector
-import it.skrape.selects.Doc
 
 /**
  * Will define a <content>-tags css query selector.
@@ -13,7 +13,7 @@ import it.skrape.selects.Doc
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.content(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.content(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("content$cssSelector", init)
 
 /**
@@ -26,7 +26,7 @@ fun <T> Doc.content(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.shadow(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.shadow(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("shadow$cssSelector", init)
 
 /**
@@ -39,7 +39,7 @@ fun <T> Doc.shadow(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.slot(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.slot(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("slot$cssSelector", init)
 
 /**
@@ -52,5 +52,5 @@ fun <T> Doc.slot(cssSelector: String = "", init: CssSelector.() -> T) =
  * @param cssSelector
  * @return T
  */
-fun <T> Doc.template(cssSelector: String = "", init: CssSelector.() -> T) =
+fun <T> CssSelectable.template(cssSelector: String = "", init: CssSelector.() -> T) =
         selection("template$cssSelector", init)


### PR DESCRIPTION
[EDIT] Removed the `DocElement` hack, still need to debate the underlying question though.

Fixes #86, #79 

This PR aims to introduce a compact class hierarchy allowing for nested/recursive CSS selections. The outwards API should not change and all the currently existing tests pass without modification.

General note: The names of the newly introduced classes are totally open for debate. Especially for `DomTreeElement` I'm struggling to find anything better.

# Class design
## JSoup / DOM
The former `Doc` and `DocElement` classes are now both inheriting from a new `DomTreeElement` class based on the fact that both classes expose `JSoup` `Element`s.

The common `DomTreeElement` parent class exposes the relevant fraction of these `JSoup` APIs, whereas CSS selection methods have been refactored into another base class (see below).

## CSSSelector
The CSS selector should be able to select children without caring about whether this is the root document node or some nested child we're selecting from. Consequently, a new abstract `CssSelectable` class was introduced to express "anything that can yield result nodes based on a CSS selector query".

Interestingly enough, `CssSelector` itself is now a `CssSelectable` allowing quick, type-safe nesting in the DSL without immediate `findFirst` or `findAll` wrappers. Therefor, all selectors in the `html5` package have also been changed to extend `CssSelectable`, regardless of whether it's actually a `Doc`, `DocElement` or even `CssSelector` in reality.

# Neat side effects
1. CssSelector does not need to hold a reference to the root document and construct one big query based on the root that selects nested files. It only holds the small part of the document that is within its current scope -- **without knowing how deep in the scope that actually is**. As a consequence, the full CSS selector needs to be compiled recursively on demand by asking the `CssSelector`'s subject for its own "parent CSS selector" and appending its own CSS selector portion to that. Not particulary resource-intensive anyways. but important to mention.
2. The `findAll` / `findFirst` / `findSecond` / etc. methods are now unified under `CssSelectable`! :tada: 

# Open questions
1. In order to satisfy current testing setup, we have to "short-circuit" css selector creation for the root document node (i.e. have it return an empty string). JSoup would however normally try to compose a "meaningful" CSS selector even on root level -- compare skrape.it `Doc#toCssSelector` and JSoup `Element#cssSelector`. Which path should this project go down moving forward?
2. `findAll` and `findFirst` are used as `infix` functions in some parts of the code. Kotlin only allows that with single-parameter methods that do not have a default value. For user convenience, would it make sense to ever want to skip these methods' parameters with a default value?
3. `DocElement` currently has some "not-clearly-defined" behaviour that we need to discuss. Say you have two nested, identical tags `<div>` and you perform a simple `div` CSS selector lookup on the outer one. JSoup then returns results with the outer and the inner one -- this conflicts with skrape.it's idea of nesting that requires only "true" child nodes (i.e. without reflexive self-reference) to be returned. Which definition should take preference here?

Happy reviewing! :D