### PR TITLE
Change matcher scoping functions for readability

### DIFF
--- a/src/main/kotlin/it/skrape/matchers/Assertions.kt
+++ b/src/main/kotlin/it/skrape/matchers/Assertions.kt
@@ -3,8 +3,7 @@ package it.skrape.matchers
 import it.skrape.core.fetcher.Result
 
 fun Result.Status.statusAssertion(value: Boolean, status: Result.Status): Result.Status {
-    generalAssertion(value, status)
-    return this
+    return this.also { generalAssertion(value, status) }
 }
 
 fun Any?.generalAssertion(value: Boolean, expected: Any?, message: String = "is equal to") {

--- a/src/main/kotlin/it/skrape/matchers/ContentTypeHeaderMatchers.kt
+++ b/src/main/kotlin/it/skrape/matchers/ContentTypeHeaderMatchers.kt
@@ -28,19 +28,19 @@ enum class ContentTypes(val value: String) {
 }
 
 infix fun ContentType.toBe(expected: ContentTypes) =
-        generalAssertion(raw() == expected.value, expected).let { this }
+        this.apply { generalAssertion(raw() == expected.value, expected) }
 
 @JvmName("to_be")
 infix fun ContentType.`to be`(expected: ContentTypes) = this toBe expected
 
 infix fun ContentType.toBeNot(expected: ContentTypes) =
-        generalAssertion(raw() != expected.value, expected).let { this }
+        this.apply { generalAssertion(raw() != expected.value, expected) }
 
 @JvmName("to_be_not")
 infix fun ContentType.`to be not`(expected: ContentTypes) = this toBeNot expected
 
 infix fun ContentType.toContain(expected: ContentTypes) =
-        generalAssertion(raw().contains(expected.value), expected).let { this }
+        this.apply { generalAssertion(raw().contains(expected.value), expected) }
 
 @JvmName("to_contain")
 infix fun ContentType.`to contain`(expected: ContentTypes) = this toContain expected

--- a/src/main/kotlin/it/skrape/matchers/Matchers.kt
+++ b/src/main/kotlin/it/skrape/matchers/Matchers.kt
@@ -4,66 +4,59 @@ import it.skrape.selects.DocElement
 import it.skrape.selects.isNotPresent
 import it.skrape.selects.isPresent
 
-infix fun Int.toBe(expected: Int): Int {
-    generalAssertion(this == expected, expected)
-    return this
-}
+infix fun Int.toBe(expected: Int) =
+        this.apply { generalAssertion(this == expected, expected) }
 
 @JvmName("to_be")
 infix fun Int.`to be`(expected: Int): Int = this toBe expected
 
-infix fun String?.toBe(expected: String?): String? {
-    generalAssertion(this == expected, expected)
-    return this
-}
+infix fun String?.toBe(expected: String?) =
+        this.apply { generalAssertion(this == expected, expected) }
 
 @JvmName("to_be")
 infix fun String?.`to be`(expected: String?): String? = this toBe expected
 
-infix fun String?.toBeNot(expected: String?): String? {
-    generalAssertion(this != expected, expected)
-    return this
-}
+infix fun String?.toBeNot(expected: String?) =
+        this.apply { generalAssertion(this != expected, expected) }
 
 @JvmName("to_be_not")
 infix fun String?.`to be not`(expected: String?): String? = this toBeNot expected
 
-infix fun String?.toContain(expected: String): String? {
-    generalAssertion("$this".contains(expected), expected)
-    return this
-}
+infix fun String?.toContain(expected: String) =
+        this.apply { generalAssertion("$this".contains(expected), expected) }
 
 @JvmName("to_contain")
 infix fun String?.`to contain`(expected: String): String? = this toContain expected
 
-infix fun String?.toNotContain(expected: String): String? {
-    generalAssertion(!"$this".contains(expected), expected)
-    return this
-}
+infix fun String?.toNotContain(expected: String) =
+        this.apply { generalAssertion(!"$this".contains(expected), expected) }
 
 @JvmName("to_not_contain")
 infix fun String?.`to not contain`(expected: String): String? = this toNotContain expected
 
-infix fun List<Any>.toContain(expected: String): List<Any> {
-    generalAssertion(this.contains(expected), expected)
-    return this
-}
+infix fun List<Any>.toContain(expected: String) =
+        this.apply { generalAssertion(this.contains(expected), expected) }
 
 @JvmName("to_contain")
 infix fun List<Any>.`to contain`(expected: String): List<Any> = this.toContain(expected)
 
 val List<DocElement>.toBePresent
-    get() = generalAssertion(
-            isPresent,
-            "${this::class}",
-            "is present"
-    ).let { this }
+    get() = this.apply {
+        generalAssertion(
+                isPresent,
+                "${this::class}",
+                "is present"
+        )
+    }
 
-infix fun List<DocElement>.toBePresentTimes(amount: Int) = generalAssertion(
-        size == amount,
-        "${this::class}",
-        "is present $amount times"
-    ).let { this }
+infix fun List<DocElement>.toBePresentTimes(amount: Int) =
+        this.apply {
+            generalAssertion(
+                    size == amount,
+                    "${this::class}",
+                    "is present $amount times"
+            )
+        }
 
 val List<DocElement>.toBePresentExactlyOnce
     get() = this toBePresentTimes 1
@@ -72,21 +65,25 @@ val List<DocElement>.toBePresentExactlyTwice
     get() = this toBePresentTimes 2
 
 val DocElement.toBePresent
-    get() = generalAssertion(
-            isPresent,
-            "element '$cssSelector'",
-            "is present"
-    ).let { this }
+    get() = this.apply {
+        generalAssertion(
+                isPresent,
+                "element '$cssSelector'",
+                "is present"
+        )
+    }
 
 val List<DocElement>.toBeNotPresent
-    get() = generalAssertion(
-            isNotPresent,
-            "${this::class}",
-            "is not present"
-    ).let { this }
+    get() = this.apply {
+        generalAssertion(
+                isNotPresent,
+                "${this::class}",
+                "is not present"
+        )
+    }
 
 val List<Any>.toBeEmpty
-    get() = generalAssertion(size == 0, "list", "is empty").let { this }
+    get() = this.apply { generalAssertion(size == 0, "list", "is empty") }
 
 val List<Any>.toBeNotEmpty
-    get() = generalAssertion(size > 0, "list", "is none empty").let { this }
+    get() = this.apply { generalAssertion(size > 0, "list", "is none empty") }


### PR DESCRIPTION
Nothing fancy here, just replacing one syntactic sugar for another.
Please proof-read that I didn't do any stupid copy/paste mistakes!

imho `return this.apply { makeSomeAssertion() }` is more concise than `return makeSomeAssertion().let{ this }`