### PR TITLE
Add cookies in Result

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/it/skrape/core/fetcher/BrowserFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/BrowserFetcher.kt
@@ -31,7 +31,8 @@ class BrowserFetcher(private val request: Request) : Fetcher {
                 responseStatus = httpResponse.toStatus(),
                 contentType = httpResponse.contentType,
                 headers = headers,
-                request = request
+                request = request,
+                cookies = httpResponse.responseHeaders.filter { it.name == "Set-Cookie" }.map { it.value.toCookie(request.url.urlOrigin()) }
         )
 
         client.javaScriptEngine.shutdown()

--- a/src/main/kotlin/it/skrape/core/fetcher/Cookie.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/Cookie.kt
@@ -1,0 +1,70 @@
+package it.skrape.core.fetcher
+
+/**
+ * Object representing a web cookie
+ */
+data class Cookie(
+    val name: String,
+    val value: String,
+    /**The maximum lifetime of the cookie as an HTTP-date timestamp. Defaults to [Expires.Session] if attribute is not specified in cookie, otherwise [Expires.Date].*/
+    val expires: Expires,
+    /**Number of seconds until the cookie expires. A zero or negative number will expire the cookie immediately. Takes precedence over [expires].*/
+    val maxAge: Int?,
+    val domain: Domain,
+    val path: String = "/",
+    val sameSite: SameSite = SameSite.LAX,
+    val secure: Boolean = false,
+    val httpOnly: Boolean = false
+)
+
+fun String.toCookie(origin: String): Cookie {
+    val attributes = this.split(";").map { it.trim() }
+    val (name, value) = attributes[0].split("=")
+
+    val path = attributes.getAttribute("path") ?: "/"
+    val expires = attributes.getAttribute("expires").toExpires()
+    val maxAge = attributes.getAttribute("max-age")?.toInt()
+    val domain = attributes.getDomain(origin)
+    val sameSite = attributes.getAttribute("samesite").toSameSite()
+    val secure = attributes.any { it.toLowerCase() == "secure" }
+    val httpOnly = attributes.any { it.toLowerCase() == "httponly" }
+    return Cookie(name, value, expires, maxAge, domain, path, sameSite, secure, httpOnly)
+}
+
+private fun List<String>.getAttribute(attributeName: String) =
+    this.find { it.startsWith("${attributeName}=", ignoreCase = true) }?.takeLastWhile { it != '=' }
+
+private fun List<String>.getDomain(origin: String): Domain {
+    val domain = getAttribute("domain") ?: return Domain(origin, false)
+    return Domain(domain, true)
+}
+
+enum class SameSite {
+    STRICT, LAX, NONE
+}
+
+fun String?.toSameSite(): SameSite {
+    return when (this?.toLowerCase()) {
+        "strict" -> SameSite.STRICT
+        "lax" -> SameSite.LAX
+        "none" -> SameSite.NONE
+        else -> SameSite.LAX
+    }
+}
+
+sealed class Expires {
+    object Session : Expires()
+    data class Date(val date: String) : Expires()
+}
+
+private fun String?.toExpires(): Expires {
+    return when(this){
+        null -> Expires.Session
+        else -> Expires.Date(this)
+    }
+}
+
+/** Remove http:// or https://, any subdirectories, and port if those exist */
+internal fun String.urlOrigin() = this.substringAfter("://").substringBefore("/").substringBefore(":")
+
+data class Domain(val domain: String, val includesSubdomains: Boolean)

--- a/src/main/kotlin/it/skrape/core/fetcher/Cookie.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/Cookie.kt
@@ -2,13 +2,20 @@ package it.skrape.core.fetcher
 
 /**
  * Object representing a web cookie
+ * @param name The name of the cookie
+ * @param value The value of the cookie
+ * @param expires The maximum lifetime of the cookie as an HTTP-date timestamp. Defaults to [Expires.Session] if attribute is not specified in cookie, otherwise [Expires.Date].
+ * @param maxAge Number of seconds until the cookie expires. A zero or negative number will expire the cookie immediately. Takes precedence over [expires]
+ * @param domain The domain that the cookie is associated with. Can apply either to only the base domain or to all subdomains based on [Domain.includesSubdomains]
+ * @param path The path that the cookie is associated with
+ * @param sameSite The [SameSite] value of the cookie
+ * @param secure If true, the cookie is only sent to the server when a request is made using https, otherwise is available in all requests
+ * @param httpOnly If true, the cookie is not accessible to javascript and can only be sent in an http request
  */
 data class Cookie(
     val name: String,
     val value: String,
-    /**The maximum lifetime of the cookie as an HTTP-date timestamp. Defaults to [Expires.Session] if attribute is not specified in cookie, otherwise [Expires.Date].*/
     val expires: Expires,
-    /**Number of seconds until the cookie expires. A zero or negative number will expire the cookie immediately. Takes precedence over [expires].*/
     val maxAge: Int?,
     val domain: Domain,
     val path: String = "/",
@@ -40,7 +47,12 @@ private fun List<String>.getDomain(origin: String): Domain {
 }
 
 enum class SameSite {
-    STRICT, LAX, NONE
+    /** Cookie is sent only to requests originating from the site that set it */
+    STRICT,
+    /** Cookie is withheld on cross-site requests (i.e. images), but sent on url navigation from external site. Default if no SameSite is specified */
+    LAX,
+    /** Cookie is send on both cross-site and same-site requests */
+    NONE
 }
 
 fun String?.toSameSite(): SameSite {

--- a/src/main/kotlin/it/skrape/core/fetcher/HttpFetcher.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/HttpFetcher.kt
@@ -25,7 +25,8 @@ class HttpFetcher(private val request: Request) : Fetcher {
                     responseStatus = it.toStatus(),
                     contentType = it.header("Content-Type"),
                     headers = it.headers().names().associateBy({ item -> item }, { item -> it.header(item, "")!! }),
-                    request = request
+                    request = request,
+                    cookies = it.headers("Set-Cookie").map { item -> item.toCookie(request.url.urlOrigin()) }
             )
         }
     }

--- a/src/main/kotlin/it/skrape/core/fetcher/Result.kt
+++ b/src/main/kotlin/it/skrape/core/fetcher/Result.kt
@@ -10,6 +10,7 @@ import it.skrape.SkrapeItDsl
  * @param contentType - the http responses content type
  * @param headers - the http responses headers
  * @param request - the initial request
+ * @param cookies - the http response's cookies
  */
 @SkrapeItDsl
 class Result(
@@ -17,7 +18,8 @@ class Result(
         val responseBody: String,
         val responseStatus: Status,
         val contentType: ContentType,
-        val headers: Map<String, String>
+        val headers: Map<String, String>,
+        val cookies: List<Cookie>
 ) {
     /**
      * Will return a certain response headers value

--- a/src/test/kotlin/it/skrape/WireMockSetup.kt
+++ b/src/test/kotlin/it/skrape/WireMockSetup.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.apache.http.impl.conn.Wire
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import java.util.*
@@ -72,6 +73,14 @@ fun WireMockServer.setupHeadStub(): StubMapping =
                 .willReturn(aResponse()
                         .withStatus(201)
                         .withHeader("result","i'm a HEAD stub")))
+
+fun WireMockServer.setupCookiesStub(path: String = "/"): StubMapping =
+    stubFor(get(urlEqualTo(path))
+            .willReturn(aResponse()
+                    .withHeader("Set-Cookie", "basic=value")
+                    .withHeader("Set-Cookie", "advanced=advancedValue; Domain=localhost; Path=$path; Secure; HttpOnly; SameSite=Strict")
+                    .withHeader("Set-Cookie", "expireTest=value; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Max-Age=2592000")
+                    .withStatus(200)))
 
 fun WireMockServer.setupBasicAuthStub(
         username: String,

--- a/src/test/kotlin/it/skrape/WireMockSetup.kt
+++ b/src/test/kotlin/it/skrape/WireMockSetup.kt
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.apache.http.impl.conn.Wire
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import java.util.*

--- a/src/test/kotlin/it/skrape/core/fetcher/BrowserFetcherTest.kt
+++ b/src/test/kotlin/it/skrape/core/fetcher/BrowserFetcherTest.kt
@@ -10,6 +10,7 @@ import it.skrape.exceptions.UnsupportedRequestOptionException
 import it.skrape.selects.eachText
 import it.skrape.selects.html5.h1
 import it.skrape.selects.html5.p
+import it.skrape.setupCookiesStub
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import strikt.api.expect
@@ -76,6 +77,20 @@ internal class BrowserFetcherTest : WireMockSetup() {
         val fetched = BrowserFetcher(Request()).fetch()
 
         expectThat(fetched.status { code }).isEqualTo(404)
+    }
+
+    @Test
+    internal fun `can fetch cookies`(){
+        wireMockServer.setupCookiesStub(path = "/cookies")
+
+        val request = Request(url = "https://localhost:8089/cookies", sslRelaxed = true)
+        val fetched = BrowserFetcher(request).fetch()
+
+        expectThat(fetched.cookies).isEqualTo(listOf(
+            Cookie("basic", "value", Expires.Session, null, Domain("localhost", false)),
+            Cookie("advanced", "advancedValue", Expires.Session, null, Domain("localhost", true), "/cookies", SameSite.STRICT, true, httpOnly = true),
+            Cookie("expireTest", "value", Expires.Date("Wed, 21 Oct 2015 07:28:00 GMT"), 2592000, Domain("localhost", false))
+        ))
     }
 
     @Test

--- a/src/test/kotlin/it/skrape/core/fetcher/HttpFetcherTest.kt
+++ b/src/test/kotlin/it/skrape/core/fetcher/HttpFetcherTest.kt
@@ -64,6 +64,18 @@ internal class HttpFetcherTest : WireMockSetup() {
         expectThat(fetched.status { code }).isEqualTo(404)
     }
 
+    @Test internal fun `can fetch cookies`(){
+        wireMockServer.setupCookiesStub(path = "/cookies")
+        val request = Request(url = "https://localhost:8089/cookies", sslRelaxed = true)
+        val fetched = HttpFetcher(request).fetch()
+
+        expectThat(fetched.cookies).isEqualTo(listOf(
+            Cookie("basic", "value", Expires.Session, null, Domain("localhost", false)),
+            Cookie("advanced", "advancedValue", Expires.Session, null, Domain("localhost", true), "/cookies", SameSite.STRICT, true, httpOnly = true),
+            Cookie("expireTest", "value", Expires.Date("Wed, 21 Oct 2015 07:28:00 GMT"), 2592000, Domain("localhost", false))
+        ))
+    }
+
     @Test
     internal fun `can fetch url and use HTTP verb POST`() {
         wireMockServer.setupPostStub()


### PR DESCRIPTION
This adds a `cookies: List<Cookie>` field to the `Result` class.
 
Addresses issue #97 

Currently the `Cookie` class mirrors the structure of the [Set-Cookie header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie), though I'm not sure if this is the best API shape for the library -- any thoughts are appreciated!