### PR TITLE
feat: #127 add ktor fetcher

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.gradle

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+
+    mavenCentral()
+
+}
+
+kotlin {
+
+    sourceSets.getByName("main").kotlin.srcDir("buildSrc/src/main/kotlin")
+}

--- a/buildSrc/buildSrc/.gitignore
+++ b/buildSrc/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+/build
+/.gradle

--- a/buildSrc/buildSrc/build.gradle.kts
+++ b/buildSrc/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    jcenter()
+}

--- a/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -1,0 +1,71 @@
+abstract class DependencyGroup(
+    val group: String,
+    val version: String
+) {
+    fun dependency(
+        name: String,
+        group: String = this.group,
+        version: String = this.version
+    ) = "$group:$name:$version"
+}
+
+object Versions {
+    const val kotlin = "1.4.31"
+    const val coroutines = "1.4.3"
+    const val ktor = "1.5.2"
+    const val serialization = "1.0.1"
+    const val datetime = "0.1.1"
+    const val jsoup = "1.13.1"
+    const val htmlUnit = "2.47.1"
+    const val kohttp = "0.12.0"
+    const val testContainers = "1.15.2"
+    const val wireMock = "2.27.2"
+    const val log4jOverSlf4j = "1.7.30"
+    const val logback = "1.2.3"
+    const val okHttp = "4.9.1"
+}
+
+object Deps {
+
+    const val jsoup = "org.jsoup:jsoup:${Versions.jsoup}"
+    const val htmlUnit = "net.sourceforge.htmlunit:htmlunit:${Versions.htmlUnit}"
+    const val okHttp = "com.squareup.okhttp3:okhttp:${Versions.okHttp}"
+    const val kOHttp = "io.github.rybalkinsd:kohttp:${Versions.kohttp}"
+    const val wireMock = "com.github.tomakehurst:wiremock-jre8:${Versions.wireMock}"
+    const val logback = "ch.qos.logback:logback-classic:${Versions.logback}"
+    const val log4jOverSlf4j = "org.slf4j:log4j-over-slf4j:${Versions.log4jOverSlf4j}"
+
+    object Ktor : DependencyGroup(
+        group = "io.ktor",
+        version = Versions.ktor
+    ) {
+        val client = dependency("ktor-client-core")
+        val clientJson = dependency("ktor-client-json")
+        val clientApache = dependency("ktor-client-apache")
+    }
+
+    object KotlinX {
+        const val dateTime = "org.jetbrains.kotlinx:kotlinx-datetime:${Versions.datetime}"
+        const val serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.serialization}"
+
+        object Coroutines : DependencyGroup(
+            group = "org.jetbrains.kotlinx",
+            version = Versions.coroutines
+        ) {
+            val test = dependency("kotlinx-coroutines-test")
+            val core = dependency("kotlinx-coroutines-core")
+        }
+    }
+
+    object TestContainers : DependencyGroup(
+        group = "org.testcontainers",
+        version = Versions.testContainers
+    ) {
+        val testContainers = dependency("testcontainers")
+        val jUnit = dependency("junit-jupiter")
+    }
+}
+
+
+
+

--- a/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -1,13 +1,3 @@
-abstract class DependencyGroup(
-    val group: String,
-    val version: String
-) {
-    fun dependency(
-        name: String,
-        group: String = this.group,
-        version: String = this.version
-    ) = "$group:$name:$version"
-}
 
 object Versions {
     const val kotlin = "1.4.31"
@@ -25,6 +15,17 @@ object Versions {
     const val okHttp = "4.9.1"
 }
 
+abstract class DependencyGroup(
+    val group: String,
+    val version: String
+) {
+    fun dependency(
+        name: String,
+        group: String = this.group,
+        version: String = this.version
+    ) = "$group:$name:$version"
+}
+
 object Deps {
 
     const val jsoup = "org.jsoup:jsoup:${Versions.jsoup}"
@@ -37,11 +38,12 @@ object Deps {
 
     object Ktor : DependencyGroup(
         group = "io.ktor",
-        version = Versions.ktor
+        version = "1.5.2"
     ) {
         val client = dependency("ktor-client-core")
         val clientJson = dependency("ktor-client-json")
         val clientApache = dependency("ktor-client-apache")
+        val clientLogging = dependency("ktor-client-logging")
     }
 
     object KotlinX {
@@ -57,6 +59,7 @@ object Deps {
         }
     }
 
+
     object TestContainers : DependencyGroup(
         group = "org.testcontainers",
         version = Versions.testContainers
@@ -64,7 +67,9 @@ object Deps {
         val testContainers = dependency("testcontainers")
         val jUnit = dependency("junit-jupiter")
     }
+
 }
+
 
 
 

--- a/fetcher/basis-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncFetcher.kt
+++ b/fetcher/basis-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncFetcher.kt
@@ -1,0 +1,7 @@
+package it.skrape.fetcher
+
+public interface AsyncFetcher<T> {
+    public suspend fun fetch(request:T):Result
+
+    public val requestBuilder: T
+}

--- a/fetcher/basis-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncScraper.kt
+++ b/fetcher/basis-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncScraper.kt
@@ -1,0 +1,52 @@
+package it.skrape.fetcher
+
+import it.skrape.SkrapeItDsl
+import kotlin.reflect.full.createInstance
+
+public class AsyncScraper<R>(public val client: AsyncFetcher<R>, public val preparedRequest: R) {
+    public constructor(client: AsyncFetcher<R>) : this(client, client.requestBuilder)
+
+    @SkrapeItDsl
+    public fun request(init: R.() -> Unit): AsyncScraper<R> {
+        this.preparedRequest.run(init)
+        return this
+    }
+
+    public suspend fun scrape(): Result =
+        client.fetch(preparedRequest)
+}
+
+/**
+ * Create a http-request config with given parameters or defaults.
+ * @return Result
+ */
+@SkrapeItDsl
+public fun <R, T> skrape(client: AsyncFetcher<R>, init: AsyncScraper<R>.() -> T): T =
+    AsyncScraper(client).init()
+
+/**
+ * Read and parse html from a skrape{it} result.
+ */
+@SkrapeItDsl
+public suspend fun AsyncScraper<*>.expect(init: Result.() -> Unit) {
+    extract(init)
+}
+
+/**
+ * Read and parse html from a skrape{it} result.
+ * @return T
+ */
+@SkrapeItDsl
+public suspend fun <T> AsyncScraper<*>.extract(extractor: Result.() -> T): T =
+    scrape().extractor()
+
+/**
+ * Read and parse html from a skrape{it} result.
+ * Attention: extract to class is only supported for classes where all parameters have default values
+ * @return T
+ */
+@SkrapeItDsl
+public suspend inline fun <reified T : Any> AsyncScraper<*>.extractIt(crossinline extractor: Result.(T) -> Unit): T {
+    val instance = T::class.createInstance()
+    return extract { instance.also { extractor(it) } }
+}

--- a/fetcher/ktor-fetcher/build.gradle.kts
+++ b/fetcher/ktor-fetcher/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    jacoco
+    kotlin("jvm")
+    id("org.jetbrains.dokka")
+}
+
+dependencies {
+    implementation(project(":fetcher:basis-fetcher"))
+    implementation(Deps.Ktor.client)
+    implementation(Deps.Ktor.clientApache)
+    testImplementation(project(path = ":test-utils", configuration = "default"))
+}

--- a/fetcher/ktor-fetcher/build.gradle.kts
+++ b/fetcher/ktor-fetcher/build.gradle.kts
@@ -8,5 +8,8 @@ dependencies {
     implementation(project(":fetcher:basis-fetcher"))
     implementation(Deps.Ktor.client)
     implementation(Deps.Ktor.clientApache)
+//    implementation(Deps.Ktor.clientLogging)
+//    implementation(Deps.logback)
+//    implementation(Deps.log4jOverSlf4j)
     testImplementation(project(path = ":test-utils", configuration = "default"))
 }

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
@@ -1,0 +1,65 @@
+package it.skrape.fetcher
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache.Apache
+import io.ktor.client.features.HttpResponseValidator
+import io.ktor.client.features.HttpTimeout
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.network.sockets.SocketTimeoutException
+import kotlinx.coroutines.runBlocking
+
+public object KtorFetcher : Fetcher<Request> {
+
+    override val requestBuilder: Request get() = Request()
+
+    override fun fetch(request: Request): Result = runBlocking { fetchAsync(request) }
+
+    public suspend fun fetchAsync(request: Request): Result = configuredClient(request).toResult()
+
+    @Suppress("MagicNumber")
+    private suspend fun configuredClient(request: Request): HttpResponse {
+
+        val client = HttpClient(Apache) {
+            expectSuccess = false
+            followRedirects = request.followRedirects
+            install(HttpTimeout)
+            request.authentication?.let { authentication: Authentication ->
+                if (authentication is BasicAuth) {
+                    installBasicAuth(authentication.username, authentication.password)
+                }
+            }
+            HttpResponseValidator {
+                validateResponse { response ->
+                    if (response.status.value >= 300) {
+                        response.toResult()
+                    }
+                }
+                handleResponseException { cause: Throwable ->
+                    when (cause) {
+                        is SocketTimeoutException -> {
+                            throw cause
+                        }
+                    }
+                }
+            }
+            engine {
+                request.proxy?.toProxy()?.toHttpHost()?.let {
+                    customizeClient {
+                        setProxy(it)
+                    }
+                }
+                connectionRequestTimeout = request.timeout
+                socketTimeout = request.timeout
+                followRedirects = request.followRedirects
+            }
+            if (request.sslRelaxed) {
+                trustSelfSignedClient()
+            }
+        }
+        return client.request(request.toHttpRequest())
+    }
+
+}
+
+

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
@@ -26,15 +26,11 @@ public object KtorFetcher : Fetcher<Request> {
             install(HttpTimeout)
             request.authentication?.let { authentication: Authentication ->
                 if (authentication is BasicAuth) {
-                    installBasicAuth(authentication.username, authentication.password)
+                    installBasicAuth()
                 }
             }
             HttpResponseValidator {
-                validateResponse { response ->
-                    if (response.status.value >= 300) {
-                        response.toResult()
-                    }
-                }
+
                 handleResponseException { cause: Throwable ->
                     when (cause) {
                         is SocketTimeoutException -> {

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/KtorFetcher.kt
@@ -7,15 +7,12 @@ import io.ktor.client.features.HttpTimeout
 import io.ktor.client.request.request
 import io.ktor.client.statement.HttpResponse
 import io.ktor.network.sockets.SocketTimeoutException
-import kotlinx.coroutines.runBlocking
 
-public object KtorFetcher : Fetcher<Request> {
+public object KtorFetcher : AsyncFetcher<Request> {
 
     override val requestBuilder: Request get() = Request()
 
-    override fun fetch(request: Request): Result = runBlocking { fetchAsync(request) }
-
-    public suspend fun fetchAsync(request: Request): Result = configuredClient(request).toResult()
+    override suspend fun fetch(request: Request): Result = configuredClient(request).toResult()
 
     @Suppress("MagicNumber")
     private suspend fun configuredClient(request: Request): HttpResponse {
@@ -55,7 +52,4 @@ public object KtorFetcher : Fetcher<Request> {
         }
         return client.request(request.toHttpRequest())
     }
-
 }
-
-

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -1,0 +1,140 @@
+package it.skrape.fetcher
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.apache.ApacheEngineConfig
+import io.ktor.client.features.defaultRequest
+import io.ktor.client.features.timeout
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.headers
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readText
+import io.ktor.client.statement.request
+import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
+import io.ktor.http.setCookie
+import io.ktor.http.toHttpDate
+import io.ktor.util.flattenEntries
+import io.ktor.util.network.hostname
+import io.ktor.util.network.port
+import org.apache.http.HttpHost
+import org.apache.http.conn.ssl.NoopHostnameVerifier
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy
+import org.apache.http.ssl.SSLContextBuilder
+import java.net.Proxy
+
+internal fun Request.toHttpRequest(): HttpRequestBuilder {
+    val request = this
+    return HttpRequestBuilder().apply {
+        method = request.method.toHttpMethod()
+        url(request.url)
+        headers {
+            request.headers.forEach { (k, v) ->
+                append(k, v)
+            }
+            append("User-Agent", request.userAgent)
+            cookies = request.cookies
+            if (request.authentication != null) {
+                append("Authorization", request.authentication!!.toHeaderValue())
+            }
+        }
+        timeout {
+            socketTimeoutMillis = request.timeout.toLong()
+        }
+    }
+}
+
+internal fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth(username: String, password: String) {
+    engine {
+        customizeRequest {
+            setAuthenticationEnabled(true)
+        }
+    }
+
+}
+
+internal fun HttpClientConfig<ApacheEngineConfig>.installTokenAuth(token: String) {
+    defaultRequest {
+        headers {
+            append("Authorization", "token $token")
+        }
+    }
+}
+
+internal fun Method.toHttpMethod(): HttpMethod = when (this) {
+    Method.GET -> HttpMethod.Get
+    Method.POST -> HttpMethod.Post
+    Method.HEAD -> HttpMethod.Head
+    Method.DELETE -> HttpMethod.Delete
+    Method.PATCH -> HttpMethod.Patch
+    Method.PUT -> HttpMethod.Put
+}
+
+internal fun io.ktor.http.Cookie.toDomainCookie(origin: String): Cookie {
+    val path = this.path ?: "/"
+    val expires = this.expires?.toHttpDate().toExpires()
+    val domain = when (val domainUrl = this.domain) {
+        null -> Domain(origin, false)
+        else -> Domain(domainUrl.urlOrigin(), true)
+    }
+    val sameSite = this.extensions["SameSite"].toSameSite()
+    val maxAge = this.maxAge.toMaxAge()
+
+    return Cookie(this.name, this.value, expires, maxAge, domain, path, sameSite, this.secure, this.httpOnly)
+}
+
+internal fun Int.toMaxAge(): Int? = when (this) {
+    0 -> null
+    else -> this
+}
+
+/** Remove http:// or https://, any subdirectories, and port if those exist */
+internal fun String.urlOrigin() = this.substringAfter("://").substringBefore("/").substringBefore(":")
+
+internal fun String?.toExpires(): Expires {
+    return when (this) {
+        null -> Expires.Session
+        else -> Expires.Date(this)
+    }
+}
+
+internal fun String?.toSameSite(): SameSite = when (this?.toLowerCase()) {
+    "strict" -> SameSite.STRICT
+    "lax" -> SameSite.LAX
+    "none" -> SameSite.NONE
+    else -> SameSite.LAX
+}
+
+internal fun HttpClientConfig<ApacheEngineConfig>.trustSelfSignedClient() {
+    engine {
+        customizeClient {
+            setSSLContext(
+                SSLContextBuilder
+                    .create()
+                    .loadTrustMaterial(TrustSelfSignedStrategy())
+                    .build()
+            )
+            setSSLHostnameVerifier(NoopHostnameVerifier())
+        }
+    }
+}
+
+internal suspend fun HttpResponse.toResult(): Result = Result(
+    responseBody = this.readText(),
+    responseStatus = this.toStatus(),
+    contentType = this.contentType()?.toString()?.replace(" ", ""),
+    headers = this.headers.flattenEntries()
+        .associateBy({ item -> item.first }, { item -> this.headers[item.first]!! }),
+    cookies = this.setCookie().map { cookie -> cookie.toDomainCookie(this.request.url.toString().urlOrigin()) },
+    baseUri = this.request.url.toString()
+)
+
+internal fun HttpResponse.toStatus() = Result.Status(this.status.value, this.status.description)
+
+internal fun Proxy.toHttpHost(): HttpHost? = when (this.type()) {
+    Proxy.NO_PROXY -> null
+    Proxy.Type.HTTP -> HttpHost(this.address().hostname, this.address().port)
+    else -> null
+}
+
+

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -135,5 +135,3 @@ internal fun Proxy.toHttpHost(): HttpHost? = when (this.type()) {
     Proxy.Type.HTTP -> HttpHost(this.address().hostname, this.address().port)
     else -> null
 }
-
-

--- a/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/ktor-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -44,13 +44,12 @@ internal fun Request.toHttpRequest(): HttpRequestBuilder {
     }
 }
 
-internal fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth(username: String, password: String) {
+internal fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth() {
     engine {
         customizeRequest {
             setAuthenticationEnabled(true)
         }
     }
-
 }
 
 internal fun HttpClientConfig<ApacheEngineConfig>.installTokenAuth(token: String) {

--- a/fetcher/ktor-fetcher/src/test/kotlin/it/skrape/fetcher/KtorFetcherTest.kt
+++ b/fetcher/ktor-fetcher/src/test/kotlin/it/skrape/fetcher/KtorFetcherTest.kt
@@ -1,0 +1,166 @@
+package it.skrape.fetcher
+
+import Testcontainer
+import org.junit.jupiter.api.Test
+import setupCookiesStub
+import setupDeleteStub
+import setupHeadStub
+import setupPatchStub
+import setupPostStub
+import setupPutStub
+import setupRedirect
+import setupStub
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import java.net.SocketTimeoutException
+
+private val wiremock = Testcontainer.wiremock
+
+class KtorFetcherTest  {
+
+    private val baseRequest by lazy { Request(url = "${wiremock.httpUrl}/") }
+
+    @Test
+    fun `can fetch https url and use HTTP verb GET by default`() {
+        wiremock.setupStub(path = "/example")
+        val request = baseRequest.copy(
+            url = "${wiremock.httpsUrl}/example",
+            sslRelaxed = true
+        )
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(200)
+        expectThat(fetched.contentType).isEqualTo("text/html;charset=utf-8")
+        expectThat(fetched.responseBody).contains("i'm the title")
+    }
+
+    @Test
+    fun `will not throw exception on non existing url`() {
+        val request = baseRequest.copy(url = "${wiremock.httpUrl}/not-existing", timeout = 9999999)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(404)
+    }
+
+    @Test
+    fun `will not follow redirects if configured`() {
+        wiremock.setupRedirect()
+        val request = baseRequest.copy(followRedirects = false)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(302)
+    }
+
+    @Test
+    fun `will follow redirect by default`() {
+        wiremock.setupRedirect()
+
+        val fetched = KtorFetcher.fetch(baseRequest)
+
+        expectThat(fetched.status { code }).isEqualTo(404)
+    }
+
+    @Test
+    fun `can fetch cookies`() {
+        wiremock.setupCookiesStub(path = "/cookies")
+        val request = baseRequest.copy(
+            url = "${wiremock.httpsUrl}/cookies",
+            sslRelaxed = true
+        )
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.cookies).isEqualTo(
+            listOf(
+                Cookie("basic", "value", Expires.Session, null, Domain("localhost", false)),
+                Cookie(
+                    "advanced",
+                    "advancedValue",
+                    Expires.Session,
+                    null,
+                    Domain("localhost", true),
+                    "/cookies",
+                    SameSite.STRICT,
+                    true,
+                    httpOnly = true
+                ),
+                Cookie(
+                    "expireTest",
+                    "value",
+                    Expires.Date("Wed, 21 Oct 2015 07:28:00 GMT"),
+                    2592000,
+                    Domain("localhost", false)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `can fetch url and use HTTP verb POST`() {
+        wiremock.setupPostStub()
+        val request = baseRequest.copy(method = Method.POST)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(200)
+        expectThat(fetched.contentType).isEqualTo("application/json;charset=utf-8")
+        expectThat(fetched.responseBody).isEqualTo("""{"data":"some value"}""")
+    }
+
+    @Test
+    fun `can fetch url and use HTTP verb PUT`() {
+        wiremock.setupPutStub()
+        val request = baseRequest.copy(method = Method.PUT)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(201)
+        expectThat(fetched.responseBody).isEqualTo("i'm a PUT stub")
+    }
+
+    @Test
+    fun `can fetch url and use HTTP verb DELETE`() {
+        wiremock.setupDeleteStub()
+        val request = baseRequest.copy(method = Method.DELETE)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(201)
+        expectThat(fetched.responseBody).isEqualTo("i'm a DELETE stub")
+    }
+
+    @Test
+    fun `can fetch url and use HTTP verb PATCH`() {
+        wiremock.setupPatchStub()
+        val request = baseRequest.copy(method = Method.PATCH)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(201)
+        expectThat(fetched.responseBody).isEqualTo("i'm a PATCH stub")
+    }
+
+    @Test
+    fun `can fetch url and use HTTP verb HEAD`() {
+        wiremock.setupHeadStub()
+        val request = baseRequest.copy(method = Method.HEAD)
+
+        val fetched = KtorFetcher.fetch(request)
+
+        expectThat(fetched.status { code }).isEqualTo(201)
+        expectThat(fetched.httpHeader("result")).isEqualTo("i'm a HEAD stub")
+    }
+
+    @Test
+    fun `will throw exception on timeout`() {
+        wiremock.setupStub(path = "/delayed", delay = 6000)
+
+        expectThrows<SocketTimeoutException> {
+            KtorFetcher.fetch(baseRequest.copy(url = "${wiremock.httpUrl}/delayed"))
+        }
+    }
+}

--- a/fetcher/ktor-fetcher/src/test/resources/__files/data.json
+++ b/fetcher/ktor-fetcher/src/test/resources/__files/data.json
@@ -1,0 +1,1 @@
+{"data":"some value"}

--- a/fetcher/ktor-fetcher/src/test/resources/__files/example.html
+++ b/fetcher/ktor-fetcher/src/test/resources/__files/example.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>i'm the title</title>
+</head>
+<body>
+i'm the body
+<h1>i'm the headline</h1>
+<header>
+    <h1>i'm the headers headline</h1>
+</header>
+<p class="foo bar fizz buzz" data-foo="bar">i'm a paragraph</p>
+<p>i'm a second paragraph</p>
+<div>
+    first div
+    <div>first divs child div</div>
+</div>
+<div>
+    second div
+    <div>second divs child div</div>
+</div>
+<div class="foo bar fizz buzz">div with class foo</div>
+<a-custom-tag>i'm a custom html5 tag</a-custom-tag>
+<a href="http://some.url">first link</a>
+<a href="http://some-other.url">second link</a>
+<a href="/relative-link">relative link</a>
+</body>
+</html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 kotlin_version=1.4.31
-
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 GROUP=it.skrape
 #VERSION_NAME=master-SNAPSHOT
 VERSION_NAME=1.0.0-alpha8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-kotlin_version=1.4.30
+kotlin_version=1.4.31
 
 GROUP=it.skrape
 #VERSION_NAME=master-SNAPSHOT

--- a/integrationtests/build.gradle.kts
+++ b/integrationtests/build.gradle.kts
@@ -3,10 +3,12 @@ plugins {
 }
 
 dependencies {
+    testImplementation("org.jetbrains:annotations:19.0.0")
     testImplementation(project(path = ":test-utils", configuration = "default"))
     testImplementation(project(path = ":html-parser", configuration = "default"))
     testImplementation(project(path = ":assertions", configuration = "default"))
     testImplementation(project(path = ":fetcher:basis-fetcher", configuration = "default"))
     testImplementation(project(path = ":fetcher:http-fetcher", configuration = "default"))
     testImplementation(project(path = ":fetcher:browser-fetcher", configuration = "default"))
+    testImplementation(project(path = ":fetcher:ktor-fetcher", configuration = "default"))
 }

--- a/integrationtests/src/test/kotlin/DslTest.kt
+++ b/integrationtests/src/test/kotlin/DslTest.kt
@@ -19,88 +19,96 @@ private val wiremock = Testcontainer.wiremock
 
 @Execution(ExecutionMode.SAME_THREAD)
 class DslTest {
+    private val fetchers = listOf(HttpFetcher, KtorFetcher)
 
     @Test
     fun `dsl can skrape by url`() {
         wiremock.setupStub(path = "/example")
-
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/example"
-            }
-
-            expect {
-
-                status {
-                    code toBe 200
-                    message toBe "OK"
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/example"
                 }
 
-                contentType toBe TEXT_HTML_UTF8
+                expect {
 
-                htmlDocument {
-
-                    title {
-                        findFirst {
-                            text toBe "i'm the title"
-                        }
+                    status {
+                        code toBe 200
+                        message toBe "OK"
                     }
 
-                    p {
-                        findAll {
-                            toBePresentTimes(2)
-                        }
-                        findFirst {
-                            attribute("data-foo") toBe "bar"
-                            text toBe "i'm a paragraph"
+                    contentType toBe TEXT_HTML_UTF8
+
+                    htmlDocument {
+
+                        title {
+                            findFirst {
+                                text toBe "i'm the title"
+                            }
                         }
 
-                        findLast {
-                            text toBe "i'm a second paragraph"
+                        p {
+                            findAll {
+                                toBePresentTimes(2)
+                            }
+                            findFirst {
+                                attribute("data-foo") toBe "bar"
+                                text toBe "i'm a paragraph"
+                            }
+
+                            findLast {
+                                text toBe "i'm a second paragraph"
+                            }
                         }
                     }
                 }
             }
         }
+
     }
 
     @Test
     fun `can call https with relaxed ssl option via DSL`() {
         wiremock.setupStub(path = "/example")
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpsUrl}/example"
-                sslRelaxed = true
-            }
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpsUrl}/example"
+                    sslRelaxed = true
+                }
 
-            expect {
-                status { code toBe 200 }
+                expect {
+                    status { code toBe 200 }
+                }
             }
         }
+
     }
 
     @Test
     fun `dsl can assert content-type in highly readable way`() {
         wiremock.setupStub(path = "/example")
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/example"
-            }
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/example"
+                }
 
-            expect {
-                contentType toContain TEXT_HTML
-                contentType toBe TEXT_HTML_UTF8
-                contentType toBeNot APPLICATION_XHTML
-                contentType toBeNot APPLICATION_GZIP
-                contentType toBeNot APPLICATION_JSON
-                contentType toBeNot APPLICATION_TAR
-                contentType toBeNot APPLICATION_XML
-                contentType toBeNot APPLICATION_XUL
-                contentType toBeNot APPLICATION_ZIP
+                expect {
+                    contentType toContain TEXT_HTML
+                    contentType toBe TEXT_HTML_UTF8
+                    contentType toBeNot APPLICATION_XHTML
+                    contentType toBeNot APPLICATION_GZIP
+                    contentType toBeNot APPLICATION_JSON
+                    contentType toBeNot APPLICATION_TAR
+                    contentType toBeNot APPLICATION_XML
+                    contentType toBeNot APPLICATION_XUL
+                    contentType toBeNot APPLICATION_ZIP
 
-                expectThat(contentType).isEqualTo("text/html;charset=utf-8")
+                    expectThat(contentType).isEqualTo("text/html;charset=utf-8")
+                }
             }
         }
     }
@@ -109,16 +117,18 @@ class DslTest {
     fun `dsl will not follow redirects if configured`() {
         wiremock.setupRedirect()
 
-        skrape(HttpFetcher) {
-            request {
-                followRedirects = false
-                url = "${wiremock.httpUrl}/"
-            }
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    followRedirects = false
+                    url = "${wiremock.httpUrl}/"
+                }
 
-            expect {
-                status {
-                    code toBe 302
-                    message toBe "Found"
+                expect {
+                    status {
+                        code toBe 302
+                        message toBe "Found"
+                    }
                 }
             }
         }
@@ -128,20 +138,22 @@ class DslTest {
     fun `dsl can check certain header`() {
         wiremock.setupStub()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-            expect {
-                val header = httpHeader("Content-Type") {
-                    expectThat(this).isEqualTo("text/html;charset=utf-8")
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/"
                 }
-                expectThat(header).isEqualTo("text/html;charset=utf-8")
+                expect {
+                    val header = httpHeader("Content-Type") {
+                        expectThat(this).isEqualTo("text/html;charset=utf-8")
+                    }
+                    expectThat(header).isEqualTo("text/html;charset=utf-8")
 
-                val nonExistingHeader = httpHeader("Non-Existing") {
-                    expectThat(this).isNull()
+                    val nonExistingHeader = httpHeader("Non-Existing") {
+                        expectThat(this).isNull()
+                    }
+                    expectThat(nonExistingHeader).isNull()
                 }
-                expectThat(nonExistingHeader).isNull()
             }
         }
     }
@@ -150,51 +162,57 @@ class DslTest {
     fun `dsl can check headers`() {
         wiremock.setupStub()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-            expect {
-                val headers = httpHeaders {
-                    expectThat(this).hasEntry("Content-Type", "text/html;charset=utf-8")
-                }
-                expectThat(headers).hasEntry("Content-Type", "text/html;charset=utf-8")
-            }
-        }
+      fetchers.forEach {
+          skrape(it) {
+              request {
+                  url = "${wiremock.httpUrl}/"
+              }
+              expect {
+                  val headers = httpHeaders {
+                      expectThat(this).hasEntry("Content-Type", "text/html;charset=utf-8")
+                  }
+                  expectThat(headers).hasEntry("Content-Type", "text/html;charset=utf-8")
+              }
+          }
+      }
     }
 
     @Test
     fun `dsl can get body`() {
         wiremock.setupStub()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-            expect {
-                htmlDocument {
-                    body {
-                        findFirst {
-                            text toContain "i'm a paragraph"
-                        }
-                    }
-                }
-            }
-        }
+       fetchers.forEach {
+           skrape(it) {
+               request {
+                   url = "${wiremock.httpUrl}/"
+               }
+               expect {
+                   htmlDocument {
+                       body {
+                           findFirst {
+                               text toContain "i'm a paragraph"
+                           }
+                       }
+                   }
+               }
+           }
+       }
     }
 
     @Test
     fun `dsl will follow redirect by default`() {
         wiremock.setupRedirect()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-            expect {
-                status {
-                    code toBe 404
-                    message toBe "Not Found"
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/"
+                }
+                expect {
+                    status {
+                        code toBe 404
+                        message toBe "Not Found"
+                    }
                 }
             }
         }
@@ -204,31 +222,33 @@ class DslTest {
     fun `dsl can fetch url and use HTTP verb POST`() {
         wiremock.setupPostStub()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-                method = Method.POST
-            }
-            expect {
+       fetchers.forEach {
+           skrape(it) {
+               request {
+                   url = "${wiremock.httpUrl}/"
+                   method = Method.POST
+               }
+               expect {
 
-                //expectThat(request.method).isEqualTo(Method.POST)
+                   //expectThat(request.method).isEqualTo(Method.POST)
 
-                status {
-                    code toBe 200
-                    message toBe "OK"
-                }
+                   status {
+                       code toBe 200
+                       message toBe "OK"
+                   }
 
-                responseStatus toBe HttpStatus.`2xx_Successful`
-                responseStatus toBe HttpStatus.`200_OK`
-                responseStatus toBeNot HttpStatus.`1xx_Informational_response`
-                responseStatus toBeNot HttpStatus.`3xx_Redirection`
-                responseStatus toBeNot HttpStatus.`4xx_Client_error`
-                responseStatus toBeNot HttpStatus.`5xx_Server_error`
+                   responseStatus toBe HttpStatus.`2xx_Successful`
+                   responseStatus toBe HttpStatus.`200_OK`
+                   responseStatus toBeNot HttpStatus.`1xx_Informational_response`
+                   responseStatus toBeNot HttpStatus.`3xx_Redirection`
+                   responseStatus toBeNot HttpStatus.`4xx_Client_error`
+                   responseStatus toBeNot HttpStatus.`5xx_Server_error`
 
-                contentType toBe APPLICATION_JSON_UTF8
-                contentType toBe "application/json;charset=utf-8"
-            }
-        }
+                   contentType toBe APPLICATION_JSON_UTF8
+                   contentType toBe "application/json;charset=utf-8"
+               }
+           }
+       }
     }
 
     @Test
@@ -236,13 +256,15 @@ class DslTest {
         wiremock.setupStub(delay = 3000)
 
         expectThrows<SocketTimeoutException> {
-            skrape(HttpFetcher) {
-                request {
-                    url = "${wiremock.httpUrl}/"
-                    timeout = 2000
-                }
-                expect {}
-            }
+           fetchers.forEach{
+               skrape(it) {
+                   request {
+                       url = "${wiremock.httpUrl}/"
+                       timeout = 2000
+                   }
+                   expect {}
+               }
+           }
         }
     }
 
@@ -250,17 +272,19 @@ class DslTest {
     fun `dsl can fetch url and extract to inferred type`() {
         wiremock.setupStub()
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-
-            val extracted = extract {
-                status {
-                    MyObject(message, "", emptyList())
+        fetchers.forEach {
+            skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/"
                 }
+
+                val extracted = extract {
+                    status {
+                        MyObject(message, "", emptyList())
+                    }
+                }
+                expectThat(extracted.message).isEqualTo("OK")
             }
-            expectThat(extracted.message).isEqualTo("OK")
         }
     }
 
@@ -268,42 +292,46 @@ class DslTest {
     fun `dsl can fetch url and extract using it`() {
         wiremock.setupStub()
 
-        val extracted = skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
+       fetchers.forEach {
+           val extracted = skrape(it) {
+               request {
+                   url = "${wiremock.httpUrl}/"
+               }
 
-            extractIt<MyOtherObject> {
-                it.message = status { message }
-            }
-        }
-        expectThat(extracted.message).isEqualTo("OK")
+               extractIt<MyOtherObject> {
+                   it.message = status { message }
+               }
+           }
+           expectThat(extracted.message).isEqualTo("OK")
+       }
     }
 
     @Test
     fun `dsl can fetch url and extract using it in DSL-ish fashion`() {
         wiremock.setupStub()
 
-        val extracted = skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
+       fetchers.forEach {
+           val extracted = skrape(it) {
+               request {
+                   url = "${wiremock.httpUrl}/"
+               }
 
-            extractIt<MyObject> {
-                it.message = status { message }
-                htmlDocument {
-                    it.allParagraphs = p { findAll { eachText } }
-                    it.paragraph = findFirst("p").text
-                    it.allLinks = findAll("[href]").eachHref
-                }
-            }
-        }
-        expect {
-            that(extracted.message).isEqualTo("OK")
-            that(extracted.paragraph).isEqualTo("i'm a paragraph")
-            that(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
-            that(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
-        }
+               extractIt<MyObject> {
+                   it.message = status { message }
+                   htmlDocument {
+                       it.allParagraphs = p { findAll { eachText } }
+                       it.paragraph = findFirst("p").text
+                       it.allLinks = findAll("[href]").eachHref
+                   }
+               }
+           }
+           expect {
+               that(extracted.message).isEqualTo("OK")
+               that(extracted.paragraph).isEqualTo("i'm a paragraph")
+               that(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
+               that(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
+           }
+       }
     }
 
     /**
@@ -314,44 +342,48 @@ class DslTest {
     fun `dsl can fetch url and extract to data class`() {
         wiremock.setupStub()
 
-        val extracted = skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
+      fetchers.forEach {
+          val extracted = skrape(it) {
+              request {
+                  url = "${wiremock.httpUrl}/"
+              }
 
-            extractIt<MyDataClass> {
-                it.httpStatusCode = status { code }
-                it.httpStatusMessage = status { message }
-                htmlDocument {
-                    it.allParagraphs = p { findAll { eachText } }
-                    it.paragraph = p { findFirst { text } }
-                    it.allLinks = a {
-                        findAll { eachHref }
-                    }
-                }
-            }
-        }
+              extractIt<MyDataClass> {
+                  it.httpStatusCode = status { code }
+                  it.httpStatusMessage = status { message }
+                  htmlDocument {
+                      it.allParagraphs = p { findAll { eachText } }
+                      it.paragraph = p { findFirst { text } }
+                      it.allLinks = a {
+                          findAll { eachHref }
+                      }
+                  }
+              }
+          }
 
-        expect {
-            that(extracted.httpStatusCode).isEqualTo(200)
-            that(extracted.httpStatusMessage).isEqualTo("OK")
-            that(extracted.paragraph).isEqualTo("i'm a paragraph")
-            that(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
-            that(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
-        }
+          expect {
+              that(extracted.httpStatusCode).isEqualTo(200)
+              that(extracted.httpStatusMessage).isEqualTo("OK")
+              that(extracted.paragraph).isEqualTo("i'm a paragraph")
+              that(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
+              that(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
+          }
+      }
     }
 
     @Test
     fun `will throw custom exception if element could not be found via lambda`() {
 
         expectThrows<ElementNotFoundException> {
-            skrape(HttpFetcher) {
-                request {
-                    url = "${wiremock.httpUrl}/"
-                }
-                expect {
-                    htmlDocument {
-                        findFirst(".nonExistent") {}
+            fetchers.forEach{
+                skrape(it) {
+                    request {
+                        url = "${wiremock.httpUrl}/"
+                    }
+                    expect {
+                        htmlDocument {
+                            findFirst(".nonExistent") {}
+                        }
                     }
                 }
             }
@@ -361,42 +393,46 @@ class DslTest {
     @Test
     fun `will return empty list if element could not be found and Doc mode is relaxed`() {
 
-        skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
-            expect {
-                htmlDocument {
-                    relaxed = true
-                    findAll(".nonExistent") {
-                        toBeEmpty
-                    }
-                    findFirst(".nonExistent") {
-                        // not throwing Exception
-                    }
-                }
-            }
-        }
+      fetchers.forEach {
+          skrape(it) {
+              request {
+                  url = "${wiremock.httpUrl}/"
+              }
+              expect {
+                  htmlDocument {
+                      relaxed = true
+                      findAll(".nonExistent") {
+                          toBeEmpty
+                      }
+                      findFirst(".nonExistent") {
+                          // not throwing Exception
+                      }
+                  }
+              }
+          }
+      }
     }
 
     @Test
     fun `will throw custom exception if element called by dsl could not be found`() {
 
         expectThrows<ElementNotFoundException> {
-            skrape(HttpFetcher) {
-                request {
-                    url = "${wiremock.httpUrl}/"
-                }
-                expect {
-                    htmlDocument {
-                        div {
-                            withId = "non-existend"
-                            withClass = "non-existend"
-                            withAttribute = "non" to "existend"
-                            withAttributeKey = "non-existend"
-                            withAttributes = listOf("non" to "existend")
-                            withAttributeKeys = listOf("non-existend")
-                            findFirst {}
+            fetchers.forEach {
+                skrape(it) {
+                    request {
+                        url = "${wiremock.httpUrl}/"
+                    }
+                    expect {
+                        htmlDocument {
+                            div {
+                                withId = "non-existend"
+                                withClass = "non-existend"
+                                withAttribute = "non" to "existend"
+                                withAttributeKey = "non-existend"
+                                withAttributes = listOf("non" to "existend")
+                                withAttributeKeys = listOf("non-existend")
+                                findFirst {}
+                            }
                         }
                     }
                 }
@@ -408,25 +444,27 @@ class DslTest {
     fun `dsl can fetch url and extract from skrape`() {
         wiremock.setupStub()
 
-        val extracted = skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-            }
+       fetchers.forEach {
+           val extracted = skrape(it) {
+               request {
+                   url = "${wiremock.httpUrl}/"
+               }
 
-            extract {
-                htmlDocument {
-                    MyObject(
-                        message = "",
-                        allParagraphs = p { findAll { eachText } },
-                        paragraph = findFirst("p").text,
-                        allLinks = selection("[href]") { findAll { eachHref } }
-                    )
-                }
-            }
-        }
-        expectThat(extracted.paragraph).isEqualTo("i'm a paragraph")
-        expectThat(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
-        expectThat(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
+               extract {
+                   htmlDocument {
+                       MyObject(
+                           message = "",
+                           allParagraphs = p { findAll { eachText } },
+                           paragraph = findFirst("p").text,
+                           allLinks = selection("[href]") { findAll { eachHref } }
+                       )
+                   }
+               }
+           }
+           expectThat(extracted.paragraph).isEqualTo("i'm a paragraph")
+           expectThat(extracted.allParagraphs).containsExactly("i'm a paragraph", "i'm a second paragraph")
+           expectThat(extracted.allLinks).containsExactly("http://some.url", "http://some-other.url", "/relative-link")
+       }
     }
 
     @Test
@@ -717,59 +755,67 @@ class DslTest {
         }
     }
 
+
     @Test
     fun `can preconfigure client`() {
 
-        val fetcher = skrape(HttpFetcher) {
-            request {
-                url = "${wiremock.httpUrl}/"
-                followRedirects = false
+        fetchers.forEach {
+            val fetcher: Scraper<Request> = skrape(it) {
+                request {
+                    url = "${wiremock.httpUrl}/"
+                    followRedirects = false
+                }
             }
+
+            wiremock.setupRedirect()
+
+            val body1 = fetcher.extract {
+                status {
+                    code toBe 302
+                    message toBe "Found"
+                }
+                responseBody
+            }
+
+            wiremock.setupRedirect()
+
+            val body2 = fetcher.apply {
+                request {
+                    followRedirects = true
+                }
+            }.extract {
+                status {
+                    code toBe 404
+                    message toBe "Not Found"
+                }
+                responseStatus toBe HttpStatus.`4xx_Client_error`
+                responseStatus toBe HttpStatus.`404_Not_Found`
+
+                responseBody
+            }
+
+            expectThat(body1).isNotEqualTo(body2)
         }
 
-        wiremock.setupRedirect()
-        val body1 = fetcher.extract {
-            status {
-                code toBe 302
-                message toBe "Found"
-            }
-            responseBody
-        }
-
-        wiremock.setupRedirect()
-        val body2 = fetcher.apply {
-            request {
-                followRedirects = true
-            }
-        }.extract {
-            status {
-                code toBe 404
-                message toBe "Not Found"
-            }
-            responseStatus toBe HttpStatus.`4xx_Client_error`
-            responseStatus toBe HttpStatus.`404_Not_Found`
-
-            responseBody
-        }
-
-        expectThat(body1).isNotEqualTo(body2)
     }
 
     @Test
     fun `can build url via dsl`() {
-        val client = skrape(HttpFetcher) {
-            request {
-                url = urlBuilder {
-                    protocol = UrlBuilder.Protocol.HTTPS
-                    port = 12345
-                    path = "/foo"
-                    queryParam = mapOf("foo" to "bar", "fizz" to "buzz")
-                    host = "foo.com"
-                }
-            }
-        }
+      fetchers.forEach {
+          val client = skrape(it) {
+              request {
+                  url = urlBuilder {
+                      protocol = UrlBuilder.Protocol.HTTPS
+                      port = 12345
+                      path = "/foo"
+                      queryParam = mapOf("foo" to "bar", "fizz" to "buzz")
+                      host = "foo.com"
+                  }
+              }
+          }
 
-        expectThat(client.preparedRequest.url).isEqualTo("https://foo.com:12345/foo?foo=bar&fizz=buzz")
+          expectThat(client.preparedRequest.url).isEqualTo("https://foo.com:12345/foo?foo=bar&fizz=buzz")
+      }
     }
 
     @Test

--- a/integrationtests/src/test/kotlin/ExperimentalDslTest.kt
+++ b/integrationtests/src/test/kotlin/ExperimentalDslTest.kt
@@ -1,4 +1,3 @@
-
 import it.skrape.core.htmlDocument
 import it.skrape.fetcher.*
 import it.skrape.matchers.*
@@ -256,5 +255,5 @@ class ExperimentalDslTest {
 
 @Suppress("unused")
 enum class FetchersTestEnum(val fetcher: Fetcher<Request>) {
-    HTTP(HttpFetcher), BROWSER(BrowserFetcher),KTOR(KtorFetcher)
+    HTTP(HttpFetcher), BROWSER(BrowserFetcher)
 }

--- a/integrationtests/src/test/kotlin/ExperimentalDslTest.kt
+++ b/integrationtests/src/test/kotlin/ExperimentalDslTest.kt
@@ -256,5 +256,5 @@ class ExperimentalDslTest {
 
 @Suppress("unused")
 enum class FetchersTestEnum(val fetcher: Fetcher<Request>) {
-    HTTP(HttpFetcher), BROWSER(BrowserFetcher)
+    HTTP(HttpFetcher), BROWSER(BrowserFetcher),KTOR(KtorFetcher)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(
     "examples:scraping",
     "fetcher:basis-fetcher",
     "fetcher:http-fetcher",
+    "fetcher:ktor-fetcher",
     "fetcher:browser-fetcher",
     "html-parser",
     "integrationtests",
@@ -22,7 +23,8 @@ pluginManagement {
     }
     plugins {
         kotlin("jvm") version kotlin_version
-        id("org.jetbrains.dokka") version kotlin_version
+        // Temporarily at 1.4.30 until version matches kotlin version (1.4.31)
+        id("org.jetbrains.dokka") version "1.4.30"
         id("com.adarshr.test-logger") version "2.1.1"
         jacoco
         id("com.github.ben-manes.versions") version "0.38.0"


### PR DESCRIPTION
Some notes on this:

I added a  suspend fetchAsync method to the implementation of KtorFetcher. Not sure if it would be better to have this in the Fetcher interface and have the fetch method call runBlocking on the suspend method.

There's quite a bit of code duplication between the HttpFetcher and KtorFetcher modules, mainly the extension functions and tests. Currently the only extension functions that are not duplicated are ones that deal with request,cookie, and response mapping. Something to think about.

I added a buildSrc module as a central place where dependencies are referenced. I only made use of it in the ktor module just in case it's not to your liking. I also updated the Kotlin plugin to 1.4.31, the dokka version is still at 1.4.30 as it hasn't caught up.

There's a typo in "basis-fetcher", I wasn't sure if it was supposed to be "basic" or "base" so I left it as is.

Let me know if you have any questions, thoughts, or critiques.

Thanks!

-Alexi