### PR TITLE
migrate to ktor 2.0

### DIFF
--- a/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -1,14 +1,14 @@
 object Versions {
-    const val kotlin = "1.5.31"
-    const val coroutines = "1.5.0"
-    const val ktor = "1.5.4"
+    const val kotlin = "1.6.21"
+    const val coroutines = "1.6.1"
+    const val ktor = "2.0.1"
     const val serialization = "1.0.1"
     const val datetime = "0.1.1"
     const val jsoup = "1.13.1" // 1.14.3
     const val htmlUnit = "2.58.0"
     const val testContainers = "1.16.2"
     const val wireMock = "2.28.0"
-    const val log4jOverSlf4j = "1.7.32"
+    const val log4jOverSlf4j = "1.7.36"
     const val logback = "1.2.7"
     const val strikt = "0.33.0"
     const val mockk = "1.12.1"
@@ -60,8 +60,8 @@ object Deps {
         val clientLogging = dependency("ktor-client-logging")
         val serverNetty = dependency("ktor-server-netty")
         val serverTestHost = dependency("ktor-server-test-host")
-        val freemarker = dependency("ktor-freemarker")
-        val locations = dependency("ktor-locations")
+        val freemarker = dependency("ktor-server-freemarker")
+        val locations = dependency("ktor-server-locations")
     }
 
     object KotlinX {

--- a/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncFetcher.kt
+++ b/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/AsyncFetcher.kt
@@ -2,11 +2,11 @@ package it.skrape.fetcher
 
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
-import io.ktor.client.features.*
-import io.ktor.client.features.logging.*
+import io.ktor.client.network.sockets.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import io.ktor.network.sockets.*
 
 public object AsyncFetcher : NonBlockingFetcher<Request> {
 
@@ -30,7 +30,7 @@ public object AsyncFetcher : NonBlockingFetcher<Request> {
             }
             HttpResponseValidator {
 
-                handleResponseException { cause: Throwable ->
+                handleResponseExceptionWithRequest { cause: Throwable, _: HttpRequest ->
                     when (cause) {
                         is SocketTimeoutException -> {
                             throw cause

--- a/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -2,7 +2,7 @@ package it.skrape.fetcher
 
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
-import io.ktor.client.features.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -30,7 +30,7 @@ internal fun Request.toHttpRequest(): HttpRequestBuilder {
             }
         }
         request.body?.run {
-            body = this
+            setBody(this)
         }
         timeout {
             socketTimeoutMillis = request.timeout.toLong()
@@ -110,7 +110,7 @@ internal fun HttpClientConfig<ApacheEngineConfig>.trustSelfSignedClient() {
 }
 
 internal suspend fun HttpResponse.toResult(): Result = Result(
-    responseBody = this.readText(),
+    responseBody = this.bodyAsText(),
     responseStatus = this.toStatus(),
     contentType = this.contentType()?.toString()?.replace(" ", ""),
     headers = this.headers.flattenEntries()

--- a/fetcher/base-fetcher/src/test/kotlin/it/skrape/fetcher/KtorAdapterTest.kt
+++ b/fetcher/base-fetcher/src/test/kotlin/it/skrape/fetcher/KtorAdapterTest.kt
@@ -23,9 +23,9 @@ class KtorAdapterTest {
 
     class KtorBlockingFetcher(val ktorClient: HttpClient) : BlockingFetcher<HttpRequestBuilder> {
         override fun fetch(request: HttpRequestBuilder): Result = runBlocking {
-            with(ktorClient.request<HttpResponse>(request)) {
+            with(ktorClient.request(request)) {
                 Result(
-                    responseBody = readText(),
+                    responseBody = bodyAsText(),
                     responseStatus = Result.Status(status.value, status.description),
                     contentType = contentType()?.toString(),
                     headers = headers.toMap().mapValues { it.value.firstOrNull().orEmpty() },

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-kotlin_version=1.6.0
+kotlin_version=1.6.21
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 release_version=1.2.1


### PR DESCRIPTION
https://ktor.io/docs/migrating-2.html

* align with ktor versions
  * kotlin 1.6.21
  * coroutines 1.6.1
* fix packages for ktor 2.0
* fix deprecated methods for ktor 2.0