### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -15,19 +20,24 @@ jobs:
         os:
           - ubuntu-latest
           - windows-2016
+      # in case one combination fails, we still want to see results from others
+      fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 
-      - name: Gradle Wrapper Cache
-        uses: actions/cache@v1
+      - name: Setup Gradle Dependencies Cache
+        uses: actions/cache@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -54,7 +64,7 @@ jobs:
           property: 'release_version'
           value: 0-SNAPSHOT
 
-      - name: Publish snapshot to maven central
+      - name: Publish snapshot to Maven Central
         if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
           - 8
         os:
           - ubuntu-latest
-          - windows-2016
+          - windows-2019
       # in case one combination fails, we still want to see results from others
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,22 +11,30 @@ on:
         description: extra text for tweet
         required: false
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Gradle Wrapper Cache
+      - name: Setup Gradle Dependencies Cache
         uses: actions/cache@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -69,7 +77,7 @@ jobs:
 #          updateFile: 'true'
 #          value: ${{ github.event.inputs.version }}
 
-      - name: Publish to maven central
+      - name: Publish to Maven Central
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEY}}
           ORG_GRADLE_PROJECT_signingKeyId: ${{secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID}}

--- a/examples/use-pre-release-version/build.gradle.kts
+++ b/examples/use-pre-release-version/build.gradle.kts
@@ -9,7 +9,7 @@ configurations.configureEach {
 }
 
 dependencies {
-    implementation("it.skrape:skrapeit:0-SNAPSHOT") {
+    implementation("it.skrape:skrapeit:1.3.0-alpha.1") {
         isChanging = true
     }
 }


### PR DESCRIPTION
- update Gradle dependency caching
- add concurrency cancellation
- add timeout, just in case
- disable fail-fast for test runs
- update deprecated Windows OS https://github.com/actions/virtual-environments/issues/5238


I copied the concurrency config from here: https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix#understanding-the-example

I copied (and tweaked) the Gradle caching from https://github.com/JetBrains/intellij-platform-plugin-template/actions/runs/242898088/workflow#L46-L58