### PR TITLE
Fix publishing browser-fetcher and html-parser artifacts

### DIFF
--- a/fetcher/browser-fetcher/build.gradle.kts
+++ b/fetcher/browser-fetcher/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
+    buildsrc.convention.`publish-jvm`
 }
 
 dependencies {

--- a/html-parser/build.gradle.kts
+++ b/html-parser/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
+    buildsrc.convention.`publish-jvm`
 }
 
 java {


### PR DESCRIPTION
Just a small fix regarding publishing all artifacts. I noticed while using snapshot release that build is failing with:
> Cause 1: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find it.skrape:browser-fetcher:0-SNAPSHOT.
Required by:
    project : > it.skrape:skrapeit:0-SNAPSHOT:20220912.093852-56
Cause 2: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find it.skrape:html-parser:0-SNAPSHOT.
Required by:
    project : > it.skrape:skrapeit:0-SNAPSHOT:20220912.093852-56
    project : > it.skrape:skrapeit:0-SNAPSHOT:20220912.093852-56 > it.skrape:assertions:0-SNAPSHOT:20220912.093852-4

`publish-jvm` plugin was missing in `build.gradle.kts` for `browser-fetcher` and `html-parser`

CC: @christian-draeger 