### PR TITLE
wholeText method for DocElement

### DIFF
--- a/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -30,6 +30,15 @@ public class DocElement internal constructor(
     public val ownText: String by lazy { element.ownText() }
 
     /**
+     * Get the (unencoded) text of all children of this element, including any newlines and spaces present in the
+     * original.
+     *
+     * @return unencoded, un-normalized text
+     * @see #text()
+     */
+    public val wholeText: String by lazy { element.wholeText() }
+
+    /**
      * Get all of the element's attributes.
      * @return Map<String, String>> of attribute key value pairs
      */

--- a/html-parser/src/test/kotlin/it/skrape/selects/DocElementKtTest.kt
+++ b/html-parser/src/test/kotlin/it/skrape/selects/DocElementKtTest.kt
@@ -71,6 +71,17 @@ class DocElementKtTest {
     }
 
     @Test
+    fun `can get the element's whole text - not-encoded, un-normalized with whitespaces etc`() {
+        expectThat(aValidElement.wholeText).isEqualTo(
+            """divs text        headline
+        paragraph
+            foo bar
+            fizz buzz
+        """
+        )
+    }
+
+    @Test
     fun `can get inner html of an element`() {
         expectThat(aValidElement.html).isEqualTo(
             """


### PR DESCRIPTION
I noticed that I cannot get unencoded, not normalized text from `DocElement`
I added property to get `wholeText` as in jsoup library + simple test
cc: @christian-draeger 