### PR TITLE
Update WireMock to 2.35.0

### DIFF
--- a/test-utils/src/main/kotlin/Testcontainer.kt
+++ b/test-utils/src/main/kotlin/Testcontainer.kt
@@ -41,7 +41,7 @@ public object Testcontainer {
 }
 
 private class WireMockContainer(
-    version: String = "2.9.0-alpine",
+    version: String = "2.35.0",
     val httpPort: Int = 8080,
     val httpsPort: Int = 8443,
 ) : GenericContainer<WireMockContainer>(DockerImageName.parse("wiremock/wiremock:$version")) {


### PR DESCRIPTION
`WireMock 2.9.0-alpine` doesn't work well on M1 chips and it's not possible to run all tests. Updating to the latest version resolves the issue 🟢 