### PR TITLE
Allow suspend functions in DSL

### DIFF
--- a/fetcher/base-fetcher/src/main/kotlin/it/skrape/fetcher/Scraper.kt
+++ b/fetcher/base-fetcher/src/main/kotlin/it/skrape/fetcher/Scraper.kt
@@ -8,8 +8,8 @@ public class Scraper<R>(public val fetcher: NonBlockingFetcher<R>, public val pr
     public constructor(client: NonBlockingFetcher<R>) : this(client, client.requestBuilder)
 
     @SkrapeItDsl
-    public fun request(init: R.() -> Unit): Scraper<R> {
-        this.preparedRequest.run(init)
+    public suspend fun request(init: suspend R.() -> Unit): Scraper<R> {
+        init(preparedRequest)
         return this
     }
 
@@ -56,7 +56,7 @@ public suspend fun <R, T> skrape(fetcher: NonBlockingFetcher<R>, init: suspend S
  */
 @SkrapeItDsl
 @Deprecated(message = "Please use 'response' instead", replaceWith = ReplaceWith("response(result)"))
-public suspend fun Scraper<*>.expect(result: Result.() -> Unit) {
+public suspend fun Scraper<*>.expect(result: suspend Result.() -> Unit) {
     response(result)
 }
 
@@ -65,7 +65,7 @@ public suspend fun Scraper<*>.expect(result: Result.() -> Unit) {
  * @return T
  */
 @SkrapeItDsl
-public fun Scraper<*>.expectBlocking(result: Result.() -> Unit) {
+public fun Scraper<*>.expectBlocking(result: suspend Result.() -> Unit) {
     runBlocking { response(result) }
 }
 
@@ -75,7 +75,7 @@ public fun Scraper<*>.expectBlocking(result: Result.() -> Unit) {
  */
 @SkrapeItDsl
 @Deprecated(message = "Please use 'response' instead", replaceWith = ReplaceWith("response(result)"))
-public suspend fun <T> Scraper<*>.extract(result: Result.() -> T): T =
+public suspend fun <T> Scraper<*>.extract(result: suspend Result.() -> T): T =
     response(result)
 
 /**
@@ -83,7 +83,7 @@ public suspend fun <T> Scraper<*>.extract(result: Result.() -> T): T =
  * @return T
  */
 @SkrapeItDsl
-public suspend fun <T> Scraper<*>.response(result: Result.() -> T): T =
+public suspend fun <T> Scraper<*>.response(result: suspend Result.() -> T): T =
     scrape().result()
 
 /**
@@ -91,7 +91,7 @@ public suspend fun <T> Scraper<*>.response(result: Result.() -> T): T =
  * @return T
  */
 @SkrapeItDsl
-public fun <T> Scraper<*>.extractBlocking(result: Result.() -> T): T =
+public fun <T> Scraper<*>.extractBlocking(result: suspend Result.() -> T): T =
     runBlocking { response(result) }
 
 /**

--- a/integrationtests/src/test/kotlin/DslTest.kt
+++ b/integrationtests/src/test/kotlin/DslTest.kt
@@ -6,6 +6,7 @@ import it.skrape.matchers.*
 import it.skrape.matchers.ContentTypes.*
 import it.skrape.selects.*
 import it.skrape.selects.html5.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.intellij.lang.annotations.Language
@@ -868,8 +869,10 @@ class DslTest {
         wiremock.setupRedirect()
 
         val body2 = fetcher.apply {
-            request {
-                followRedirects = true
+            runBlocking {
+                request {
+                    followRedirects = true
+                }
             }
         }.extractBlocking {
             status {
@@ -1132,6 +1135,21 @@ class DslTest {
             "some.crazy selectorThat[doesnt] exists" {
                 // in none relaxed mode it would throw an ElementNotFoundException when trying to find element without success
                 findAll { toBeEmpty }
+            }
+        }
+    }
+
+    @Test
+    fun `dsl can can suspend in request and response methods`() {
+        wiremock.setupStub()
+
+        skrape(HttpFetcher) {
+            request {
+                url = "${wiremock.httpUrl}/"
+                delay(10)
+            }
+            response {
+                delay(10)
             }
         }
     }


### PR DESCRIPTION
I've encountered a case where it would be helpful to use a suspend function directly from `SkrapeItDsl`. 

Here is a simplified example:
```
skrape(AsyncFetcher) {
    request {
        method = Method.POST
        url = "https://www.someendpoint.com"
        headers = mapOf(
            "test" to suspendGetHeader()
        )
    }

    response {
        val testHeader = headers["test"]
        suspendSaveHeader(testHeader)
    }
}
```

The above code won't compile because suspend functions cannot be called from the DSL. Looking at the source code I've noticed this limitation is caused by the missing suspend modifiers and could be easily changed.

It's easy to solve this problem by extracting suspend functions outside of the DSL and everything will work, but I thought I'll propose adding support to the DSL. Please tell me what you think.