### PR TITLE
docs: update javadoc code and link to kdoc

### DIFF
--- a/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -12,7 +12,7 @@ public class DocElement internal constructor(
     public constructor(element: Element) : this(element, false)
 
     /**
-     * Get the name of the tag for this element. E.g. {@code div}.
+     * Get the name of the tag for this element. E.g. `div`.
      *
      * @return String of the tag's name
      */
@@ -20,9 +20,9 @@ public class DocElement internal constructor(
 
     /**
      * Gets the text owned by this element only; does not get the combined text of all children.
-     * For example, given HTML `<p>Hello <b>there</b> now!</p>`, `p.ownText()` returns `"Hello now!",
+     * For example, given HTML `<p>Hello <b>there</b> now!</p>`, `p.ownText()` returns `"Hello now!"`,
      * whereas `text` returns `"Hello there now!"`.
-     * Note that the text within the {@code b} element is not returned, as it is not a direct child of the {@code p} element.
+     * Note that the text within the `b` element is not returned, as it is not a direct child of the `p` element.
      *
      * @return unencoded text, or empty string if none.
      * @see text

--- a/html-parser/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -10,7 +10,7 @@ public abstract class DomTreeElement : CssSelectable() {
     /**
      * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.
      * <p>
-     * For example, given HTML {@code <p>Hello <b>there</b> now! </p>}, {@code p.text()} returns {@code "Hello there now!"}
+     * For example, given HTML `<p>Hello <b>there</b> now! </p>`, `p.text()` returns `"Hello there now!"`
      *
      * @return unencoded, normalized text, or empty string if none.
      * @see #wholeText() if you don't want the text to be normalized.
@@ -20,15 +20,15 @@ public abstract class DomTreeElement : CssSelectable() {
     public val text: String by lazy { element.text() }
 
     /**
-     * Retrieves the element's inner HTML. E.g. on a {@code <div>} with one empty {@code <p>}, would return
-     * {@code <p></p>}. (Whereas {@link outerHtml} would return {@code <div><p></p></div>}.)
+     * Retrieves the element's inner HTML. E.g. on a `<div>` with one empty `<p>`, would return
+     * `<p></p>`. (Whereas [outerHtml] would return `<div><p></p></div>`.)
      * @return String of HTML.
      * @see outerHtml
      */
     public val html: String by lazy { element.html() }
 
     /**
-     * Get the outer HTML of this node. For example, on a {@code p} element, may return {@code <p>Para</p>}.
+     * Get the outer HTML of this node. For example, on a `p` element, may return `<p>Para</p>`.
      * @return outer HTML
      * @see html
      * @see text


### PR DESCRIPTION
Issue: https://github.com/skrapeit/skrape.it/issues/195

* updated {@link htmlLink } to [htmlLink]
* updated {@code true} to `true`

Now should comply to KDoc syntax