### PR TITLE
Propagate relaxed property

### DIFF
--- a/html-parser/src/main/kotlin/it/skrape/selects/CssSelectable.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/CssSelectable.kt
@@ -22,8 +22,8 @@ public abstract class CssSelectable {
     public operator fun <T> String.invoke(init: CssSelector.() -> T): T =
             this@CssSelectable.selection(this, init)
 
-    public open fun makeDefault(cssSelector: String): DocElement {
-        return DocElement(Element("${UUID.randomUUID()}"))
+    public open fun makeDefault(cssSelector: String, relaxed: Boolean = false): DocElement {
+        return DocElement(Element("${UUID.randomUUID()}"), relaxed)
     }
 
     /**

--- a/html-parser/src/main/kotlin/it/skrape/selects/Doc.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/Doc.kt
@@ -24,6 +24,10 @@ public class Doc(public val document: Document, override var relaxed: Boolean = 
     override val toCssSelector: String = ""
 
     override fun makeDefaultElement(cssSelector: String): DocElement {
-        return DocElement(Element(cssSelector), relaxed)
+        return DocElement(Element(cssSelector), this.relaxed)
+    }
+
+    override fun makeDefault(cssSelector: String, relaxed: Boolean): DocElement {
+        return super.makeDefault(cssSelector, this.relaxed)
     }
 }

--- a/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/DocElement.kt
@@ -185,6 +185,10 @@ public class DocElement internal constructor(
             withAttributeKeys = attributes.filterValues { it.isBlank() }.map { it.key }.orNull()
         ).toString()
     }
+
+    override fun makeDefault(cssSelector: String, relaxed: Boolean): DocElement {
+        return super.makeDefault(cssSelector, this.relaxed)
+    }
 }
 
 public val List<DocElement>.text: String

--- a/html-parser/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
+++ b/html-parser/src/main/kotlin/it/skrape/selects/DomTreeElement.kt
@@ -75,10 +75,10 @@ public abstract class DomTreeElement : CssSelectable() {
                     .associate { it.attribute("alt") to it.attribute("src") }
 
     public open fun makeDefaultElement(cssSelector: String): DocElement {
-        return super.makeDefault(cssSelector)
+        return super.makeDefault(cssSelector, this.relaxed)
     }
 
-    override fun makeDefault(cssSelector: String): DocElement {
+    override fun makeDefault(cssSelector: String, relaxed: Boolean): DocElement {
         return if (relaxed) makeDefaultElement(cssSelector) else throw ElementNotFoundException(cssSelector)
     }
 

--- a/html-parser/src/test/kotlin/it/skrape/selects/DocTest.kt
+++ b/html-parser/src/test/kotlin/it/skrape/selects/DocTest.kt
@@ -4,12 +4,14 @@ import it.skrape.core.htmlDocument
 import org.jsoup.nodes.Element
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.containsExactly
 import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFailure
 
 class DocTest {
 
@@ -86,6 +88,20 @@ class DocTest {
     fun `will return empty element in relaxed mode if element could not be found`() {
         val doc = Doc(aValidDocument().document, relaxed = true)
         expectThat(doc.findFirst(".non-existent").text).isEmpty()
+    }
+
+    @Test
+    fun `will throw exception when non relaxed and finding over defaulted element`() {
+        val doc = Doc(aValidDocument().document, relaxed = false)
+        expectCatching { doc.findFirst(".non-existent").findFirst(".non-existing") }
+            .isFailure()
+            .isA<ElementNotFoundException>()
+    }
+
+    @Test
+    fun `will return a default element when relaxed and finding over a defaulted element`() {
+        val doc = Doc(aValidDocument().document, relaxed = true)
+        expectThat(doc.findFirst(".non-existent").findFirst(".non-existing").text).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
This change propagates the relaxed property when creating default elements.

Now, when a default element is created, the relaxed property is not passed so those elements will never be relaxed. With this change, any nested hierarchy of default elements will still be relaxed.