### PR TITLE
Update kover and do a little clean up

### DIFF
--- a/assertions/build.gradle.kts
+++ b/assertions/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
 plugins {
     buildsrc.convention.base
+    buildsrc.convention.kover
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
-
-    id("org.jetbrains.kotlinx.kover")
-
     id("io.github.gradle-nexus.publish-plugin")
 }
 
@@ -18,17 +16,20 @@ dependencies {
     api(projects.fetcher.asyncFetcher)
     api(projects.fetcher.baseFetcher)
     api(projects.fetcher.browserFetcher)
-    api(projects.dsl)
     api(projects.fetcher.httpFetcher)
+    api(projects.dsl)
     api(projects.htmlParser)
-}
 
-tasks.withType<Test>().configureEach {
-    finalizedBy(tasks.koverReport, tasks.koverCollectReports)
-}
-
-kover {
-    coverageEngine.set(kotlinx.kover.api.CoverageEngine.INTELLIJ)
+    kover(projects.assertions)
+    kover(projects.fetcher.asyncFetcher)
+    kover(projects.fetcher.baseFetcher)
+    kover(projects.fetcher.browserFetcher)
+    kover(projects.fetcher.httpFetcher)
+    kover(projects.dsl)
+    kover(projects.htmlParser)
+    kover(projects.ktorExtension)
+    kover(projects.mockMvcExtension)
+    kover(projects.testUtils)
 }
 
 nexusPublishing {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ val gradleNexusPublishPlugin = "1.1.0"
 val gradleTestLoggerPlugin = "3.1.0"
 val gradleVersionsPlugin = "0.39.0"
 val kotlinDokkaPlugin = "1.6.21"
-val kotlinxKoverPlugin = "0.5.0"
+val kotlinxKoverPlugin = "0.7.3"
 val useLatestVersionsPlugin = "0.2.18"
 
 dependencies {
@@ -26,6 +26,6 @@ dependencies {
     implementation("com.adarshr:gradle-test-logger-plugin:$gradleTestLoggerPlugin")
     implementation("com.github.ben-manes:gradle-versions-plugin:$gradleVersionsPlugin")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:$kotlinDokkaPlugin")
-    implementation("org.jetbrains.kotlinx:kover:$kotlinxKoverPlugin")
+    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:$kotlinxKoverPlugin")
     implementation("se.patrikerdes:gradle-use-latest-versions-plugin:$useLatestVersionsPlugin")
 }

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -3,7 +3,6 @@ object Versions {
     const val coroutines = "1.6.1"
     const val ktor = "2.0.3" //2.0.1
     const val serialization = "1.0.1"
-    const val datetime = "0.1.1"
     const val jsoup = "1.13.1" // 1.14.3
     const val htmlUnit = "2.63.0"
     const val testContainers = "1.16.2"
@@ -55,7 +54,6 @@ object Deps {
         version = Versions.ktor
     ) {
         val client = dependency("ktor-client-core")
-        val clientJson = dependency("ktor-client-json")
         val clientApache = dependency("ktor-client-apache")
         val clientLogging = dependency("ktor-client-logging")
         val serverNetty = dependency("ktor-server-netty")
@@ -65,7 +63,6 @@ object Deps {
     }
 
     object KotlinX {
-        const val dateTime = "org.jetbrains.kotlinx:kotlinx-datetime:${Versions.datetime}"
         const val serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.serialization}"
 
         object Coroutines : DependencyGroup(

--- a/buildSrc/src/main/kotlin/buildsrc/convention/kover.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/convention/kover.gradle.kts
@@ -1,0 +1,10 @@
+package buildsrc.convention
+
+plugins {
+    base
+    id("org.jetbrains.kotlinx.kover")
+}
+
+tasks.check {
+    dependsOn(tasks.koverXmlReport)
+}

--- a/dsl/build.gradle.kts
+++ b/dsl/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }

--- a/fetcher/async-fetcher/build.gradle.kts
+++ b/fetcher/async-fetcher/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/async-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -46,14 +46,6 @@ internal fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth() {
     }
 }
 
-internal fun HttpClientConfig<ApacheEngineConfig>.installTokenAuth(token: String) {
-    defaultRequest {
-        headers {
-            append("Authorization", "token $token")
-        }
-    }
-}
-
 internal fun Method.toHttpMethod(): HttpMethod = when (this) {
     Method.GET -> HttpMethod.Get
     Method.POST -> HttpMethod.Post

--- a/fetcher/base-fetcher/build.gradle.kts
+++ b/fetcher/base-fetcher/build.gradle.kts
@@ -5,6 +5,7 @@ val kotlin_version: String by project
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/fetcher/browser-fetcher/build.gradle.kts
+++ b/fetcher/browser-fetcher/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/fetcher/http-fetcher/build.gradle.kts
+++ b/fetcher/http-fetcher/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/HttpFetcher.kt
+++ b/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/HttpFetcher.kt
@@ -101,14 +101,6 @@ private fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth() {
     }
 }
 
-private fun HttpClientConfig<ApacheEngineConfig>.installTokenAuth(token: String) {
-    defaultRequest {
-        headers {
-            append("Authorization", "token $token")
-        }
-    }
-}
-
 private fun Method.toHttpMethod(): HttpMethod = when (this) {
     Method.GET -> HttpMethod.Get
     Method.POST -> HttpMethod.Post

--- a/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/HttpFetcher.kt
+++ b/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/HttpFetcher.kt
@@ -7,15 +7,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import io.ktor.http.*
-import io.ktor.util.*
-import io.ktor.util.network.*
 import kotlinx.coroutines.runBlocking
-import org.apache.http.HttpHost
-import org.apache.http.conn.ssl.NoopHostnameVerifier
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy
-import org.apache.http.ssl.SSLContextBuilder
-import java.net.Proxy
 import java.net.URL
 
 public object HttpFetcher : BlockingFetcher<Request> {
@@ -67,110 +59,4 @@ public object HttpFetcher : BlockingFetcher<Request> {
         }.use {
             runBlocking { it.request(request.toHttpRequest()) }
         }
-}
-
-private fun Request.toHttpRequest(): HttpRequestBuilder {
-    val request = this
-    return HttpRequestBuilder().apply {
-        method = request.method.toHttpMethod()
-        url(request.url)
-        headers {
-            request.headers.forEach { (k, v) ->
-                append(k, v)
-            }
-            append("User-Agent", request.userAgent)
-            cookies = request.cookies
-            request.authentication?.run {
-                append("Authorization", toHeaderValue())
-            }
-        }
-        request.body?.run {
-            setBody(this)
-        }
-        timeout {
-            socketTimeoutMillis = request.timeout.toLong()
-        }
-    }
-}
-
-private fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth() {
-    engine {
-        customizeRequest {
-            setAuthenticationEnabled(true)
-        }
-    }
-}
-
-private fun Method.toHttpMethod(): HttpMethod = when (this) {
-    Method.GET -> HttpMethod.Get
-    Method.POST -> HttpMethod.Post
-    Method.HEAD -> HttpMethod.Head
-    Method.DELETE -> HttpMethod.Delete
-    Method.PATCH -> HttpMethod.Patch
-    Method.PUT -> HttpMethod.Put
-}
-
-private fun io.ktor.http.Cookie.toDomainCookie(origin: String): Cookie {
-    val path = this.path ?: "/"
-    val expires = this.expires?.toHttpDate().toExpires()
-    val domain = when (val domainUrl = this.domain) {
-        null -> Domain(origin, false)
-        else -> Domain(domainUrl.urlOrigin, true)
-    }
-    val sameSite = this.extensions["SameSite"].toSameSite()
-    val maxAge = this.maxAge.toMaxAge()
-
-    return Cookie(this.name, this.value, expires, maxAge, domain, path, sameSite, this.secure, this.httpOnly)
-}
-
-private fun Int.toMaxAge(): Int? = when (this) {
-    0 -> null
-    else -> this
-}
-
-private fun String?.toExpires(): Expires {
-    return when (this) {
-        null -> Expires.Session
-        else -> Expires.Date(this)
-    }
-}
-
-private fun String?.toSameSite(): SameSite = when (this?.toLowerCase()) {
-    "strict" -> SameSite.STRICT
-    "lax" -> SameSite.LAX
-    "none" -> SameSite.NONE
-    else -> SameSite.LAX
-}
-
-private fun HttpClientConfig<ApacheEngineConfig>.trustSelfSignedClient() {
-    engine {
-        customizeClient {
-            setSSLContext(
-                SSLContextBuilder
-                    .create()
-                    .loadTrustMaterial(TrustSelfSignedStrategy())
-                    .build()
-            )
-            setSSLHostnameVerifier(NoopHostnameVerifier())
-        }
-    }
-}
-
-private fun HttpResponse.toResult(): Result =
-    Result(
-        responseBody = runBlocking { bodyAsText() },
-        responseStatus = toStatus(),
-        contentType = contentType()?.toString()?.replace(" ", ""),
-        headers = headers.flattenEntries()
-            .associateBy({ item -> item.first }, { item -> headers[item.first]!! }),
-        cookies = setCookie().map { cookie -> cookie.toDomainCookie(request.url.toString().urlOrigin) },
-        baseUri = request.url.toString()
-    )
-
-private fun HttpResponse.toStatus() = Result.Status(this.status.value, this.status.description)
-
-private fun Proxy.toHttpHost(): HttpHost? = when (this.type()) {
-    Proxy.NO_PROXY -> null
-    Proxy.Type.HTTP -> HttpHost(this.address().hostname, this.address().port)
-    else -> null
 }

--- a/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
+++ b/fetcher/http-fetcher/src/main/kotlin/it/skrape/fetcher/extensions.kt
@@ -1,0 +1,123 @@
+package it.skrape.fetcher
+
+import io.ktor.client.*
+import io.ktor.client.engine.apache.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.util.*
+import io.ktor.util.network.*
+import kotlinx.coroutines.runBlocking
+import org.apache.http.HttpHost
+import org.apache.http.conn.ssl.NoopHostnameVerifier
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy
+import org.apache.http.ssl.SSLContextBuilder
+import java.net.Proxy
+
+
+internal fun Request.toHttpRequest(): HttpRequestBuilder {
+    val request = this
+    return HttpRequestBuilder().apply {
+        method = request.method.toHttpMethod()
+        url(request.url)
+        headers {
+            request.headers.forEach { (k, v) ->
+                append(k, v)
+            }
+            append("User-Agent", request.userAgent)
+            cookies = request.cookies
+            request.authentication?.run {
+                append("Authorization", toHeaderValue())
+            }
+        }
+        request.body?.run {
+            setBody(this)
+        }
+        timeout {
+            socketTimeoutMillis = request.timeout.toLong()
+        }
+    }
+}
+
+internal fun HttpClientConfig<ApacheEngineConfig>.installBasicAuth() {
+    engine {
+        customizeRequest {
+            setAuthenticationEnabled(true)
+        }
+    }
+}
+
+private fun Method.toHttpMethod(): HttpMethod = when (this) {
+    Method.GET -> HttpMethod.Get
+    Method.POST -> HttpMethod.Post
+    Method.HEAD -> HttpMethod.Head
+    Method.DELETE -> HttpMethod.Delete
+    Method.PATCH -> HttpMethod.Patch
+    Method.PUT -> HttpMethod.Put
+}
+
+private fun io.ktor.http.Cookie.toDomainCookie(origin: String): Cookie {
+    val path = this.path ?: "/"
+    val expires = this.expires?.toHttpDate().toExpires()
+    val domain = when (val domainUrl = this.domain) {
+        null -> Domain(origin, false)
+        else -> Domain(domainUrl.urlOrigin, true)
+    }
+    val sameSite = this.extensions["SameSite"].toSameSite()
+    val maxAge = this.maxAge.toMaxAge()
+
+    return Cookie(this.name, this.value, expires, maxAge, domain, path, sameSite, this.secure, this.httpOnly)
+}
+
+private fun Int.toMaxAge(): Int? = when (this) {
+    0 -> null
+    else -> this
+}
+
+private fun String?.toExpires(): Expires {
+    return when (this) {
+        null -> Expires.Session
+        else -> Expires.Date(this)
+    }
+}
+
+private fun String?.toSameSite(): SameSite = when (this?.toLowerCase()) {
+    "strict" -> SameSite.STRICT
+    "lax" -> SameSite.LAX
+    "none" -> SameSite.NONE
+    else -> SameSite.LAX
+}
+
+internal fun HttpClientConfig<ApacheEngineConfig>.trustSelfSignedClient() {
+    engine {
+        customizeClient {
+            setSSLContext(
+                SSLContextBuilder
+                    .create()
+                    .loadTrustMaterial(TrustSelfSignedStrategy())
+                    .build()
+            )
+            setSSLHostnameVerifier(NoopHostnameVerifier())
+        }
+    }
+}
+
+internal fun HttpResponse.toResult(): Result =
+    Result(
+        responseBody = runBlocking { bodyAsText() },
+        responseStatus = toStatus(),
+        contentType = contentType()?.toString()?.replace(" ", ""),
+        headers = headers.flattenEntries()
+            .associateBy({ item -> item.first }, { item -> headers[item.first]!! }),
+        cookies = setCookie().map { cookie -> cookie.toDomainCookie(request.url.toString().urlOrigin) },
+        baseUri = request.url.toString()
+    )
+
+private fun HttpResponse.toStatus() = Result.Status(this.status.value, this.status.description)
+
+internal fun Proxy.toHttpHost(): HttpHost? = when (this.type()) {
+    Proxy.NO_PROXY -> null
+    Proxy.Type.HTTP -> HttpHost(this.address().hostname, this.address().port)
+    else -> null
+}

--- a/html-parser/build.gradle.kts
+++ b/html-parser/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 java {

--- a/ktor-extension/build.gradle.kts
+++ b/ktor-extension/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/mock-mvc-extension/build.gradle.kts
+++ b/mock-mvc-extension/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
     buildsrc.convention.`publish-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     buildsrc.convention.`kotlin-jvm`
+    buildsrc.convention.kover
 }
 
 dependencies {


### PR DESCRIPTION
First I just wanted to clean up a bit :) That's why I created `http-fetcher/extensions.kt` to keep the structure aligned with  async-fetcher's structure. And that is also why I removed some unused code.

- After I created `http-fetcher/extensions.kt`, kover always ran into an `ArrayIndexOutOfBoundsException`. A quick look at the changelog shows that the problem is [fixed in version 0.6.1](https://github.com/Kotlin/kotlinx-kover/blob/main/CHANGELOG.md#061--2022-10-03). So I updated to 0.6.1 according to the [Migration Guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.6.0/docs/migration-to-0.6.0.md)

- After that, it was natural to go one step further and update directly to the latest version [0.7.3](https://github.com/Kotlin/kotlinx-kover/blob/main/CHANGELOG.md#073--2023-07-26). There is also a [Migration Guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.7.0/docs/gradle-plugin/migrations/migration-to-0.7.0.md) for this.

---

**Which projects are included in the merged coverage report?**
All except `examples/*` (see the [root build.gradle.kts](build.gradle.kts))

**Merged Xml Report**
Will still be stored where the gradle pipeline expects it to be: `./build/reports/kover/report.xml`

**Merged Html Report**
Will no longer be created. Let me know if it is needed somewhere and I will add it again.

I did some tests but that doesn't mean that everything works as it should on the Gitlab CI server. Therefore, I gladly accept feedback and adjust again if necessary.