### PR TITLE
fix: README.md for 1.0.0-alpha8

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All our official/stable releases will be published to [mavens central repository
 
 ```kotlin
 dependencies {
-    implementation("it.skrape:skrapeit-core:1.0.0-alpha6")
+    implementation("it.skrape:skrapeit-core:1.0.0-alpha8")
 }
 ```
 </details>


### PR DESCRIPTION
Currently, my project is using version 1.0.0-alpha6. However, when running the build in GitHub Actions, I encountered the following message:

```
Could not find io.strikt:strikt-core:0.24.0.
     Required by:
         *** > it.skrape:skrapeit-core:1.0.0-alpha6
```

It seems like this issue occurred because version 1.0.0-alpha6 of skrape.it was changed to alpha8. However, the README.md file of version alpha8 is instructing to add dependencies for version 1.0.0-alpha6, so I modified this.

